### PR TITLE
feat(meta-cli): link `openssl` statically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,6 +2512,7 @@ dependencies = [
  "lazy_static",
  "log",
  "notify",
+ "openssl",
  "pathdiff",
  "prisma-models",
  "project-root",

--- a/meta-cli/Cargo.toml
+++ b/meta-cli/Cargo.toml
@@ -59,6 +59,7 @@ typescript = { path = "../libs/typescript" }
 walkdir = "2.3.2"
 serde_yaml = "0.9.16"
 pathdiff = "0.2.1"
+openssl = { version = "0.10.45", features = ["vendored"] }
 
 [dev-dependencies]
 insta = "1.23.0"


### PR DESCRIPTION
Link `openssl` statically to avoid the need of installing `libssl` for `meta-cli`.

Before these changes:

```
// ldd meta

- linux-vdso.so
- libbz2.so
- libssl.so
- libcrypto.so
- libgcc_s.so
- libm.so
- libc.so
- /lib/ld-linux.so
```

After these changes:

```
// ldd meta

- linux-vdso.so
- libbz2.so
- libgcc_s.so
- libm.so
- libc.so
- /lib/ld-linux.so
```