### PR TITLE
feat: Pre-registered public policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.2.3"
+version = "0.2.4-0+dev"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.2.3"
+version = "0.2.4-0+dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "meta-cli"
-version = "0.2.3"
+version = "0.2.4-0+dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "native"
-version = "0.2.3"
+version = "0.2.4-0+dev"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7594,7 +7594,7 @@ dependencies = [
 
 [[package]]
 name = "typegraph_core"
-version = "0.2.3"
+version = "0.2.4-0+dev"
 dependencies = [
  "common",
  "enum_dispatch",
@@ -7621,7 +7621,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typescript"
-version = "0.2.3"
+version = "0.2.4-0+dev"
 dependencies = [
  "anyhow",
  "dprint-plugin-typescript",
@@ -8469,7 +8469,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.3"
+version = "0.2.4-0+dev"
 dependencies = [
  "anyhow",
  "clap",

--- a/typegate/tests/policies/policies.py
+++ b/typegate/tests/policies/policies.py
@@ -1,4 +1,4 @@
-from typegraph import typegraph, t, Graph
+from typegraph import typegraph, t, Graph, Policy
 from typegraph.graph.params import Auth
 from typegraph.runtimes.deno import DenoRuntime
 
@@ -35,5 +35,26 @@ def policies(g: Graph):
                     code="() => ({ id: 12 })",
                 )
             }
+        ),
+    )
+
+
+@typegraph()
+def multiple_public_policies(g: Graph):
+    deno = DenoRuntime()
+
+    record = t.struct(
+        {
+            "id": t.integer(),
+        },
+        name="Record",
+    )
+
+    g.expose(
+        record1=deno.static(record, {"id": 1}).with_policy(
+            Policy.public(),
+        ),
+        record2=deno.static(record, {"id": 2}).with_policy(
+            Policy.public(),
         ),
     )

--- a/typegate/tests/policies/policies_test.ts
+++ b/typegate/tests/policies/policies_test.ts
@@ -20,6 +20,7 @@ async function genSecretKey(): Promise<Record<string, string>> {
 Meta.test("Policies", async (t) => {
   const e = await t.engine("policies/policies.py", {
     secrets: await genSecretKey(),
+    typegraph: "policies",
   });
 
   await t.should("have public access", async () => {
@@ -195,6 +196,7 @@ Meta.test("Role jwt policy access", async (t) => {
 Meta.test("Namespace policies", async (t) => {
   const e = await t.engine("policies/policies.py", {
     secrets: await genSecretKey(),
+    typegraph: "policies",
   });
 
   await t.should("fail when no policy", async () => {

--- a/typegraph/core/src/global_store.rs
+++ b/typegraph/core/src/global_store.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::errors::{self, Result};
-use crate::runtimes::{DenoMaterializer, Materializer, MaterializerDenoModule, Runtime};
+use crate::runtimes::{
+    DenoMaterializer, Materializer, MaterializerData, MaterializerDenoModule, Runtime,
+};
 use crate::types::{Struct, Type, TypeFun, TypeId, WrapperTypeData};
 use crate::wit::core::{Policy as CorePolicy, PolicyId, RuntimeId};
 use crate::wit::utils::Auth as WitAuth;
@@ -46,6 +48,8 @@ pub struct Store {
     predefined_deno_functions: HashMap<String, MaterializerId>,
     deno_modules: HashMap<String, MaterializerId>,
 
+    public_policy_id: PolicyId,
+
     prisma_migration_runtime: RuntimeId,
     typegate_runtime: RuntimeId,
     typegraph_runtime: RuntimeId,
@@ -55,6 +59,7 @@ pub struct Store {
 
 impl Store {
     fn new() -> Self {
+        let deno_runtime = 0;
         Self {
             runtimes: vec![
                 Runtime::Deno,
@@ -62,10 +67,26 @@ impl Store {
                 Runtime::Typegate,
                 Runtime::Typegraph,
             ],
-            deno_runtime: 0,
+            deno_runtime,
             prisma_migration_runtime: 1,
             typegate_runtime: 2,
             typegraph_runtime: 3,
+
+            materializers: vec![Materializer {
+                runtime_id: deno_runtime,
+                effect: Effect::Read,
+                data: MaterializerData::Deno(Rc::new(DenoMaterializer::Predefined(
+                    crate::wit::runtimes::MaterializerDenoPredefined {
+                        name: "true".to_string(),
+                    },
+                ))),
+            }],
+
+            policies: vec![Rc::new(CorePolicy {
+                name: "__public".to_string(),
+                materializer: 0,
+            })],
+            public_policy_id: 0,
             ..Default::default()
         }
     }
@@ -245,6 +266,10 @@ impl Store {
                 .cloned()
                 .ok_or_else(|| errors::object_not_found("policy", id))
         })
+    }
+
+    pub fn get_public_policy_id() -> PolicyId {
+        with_store(|s| s.public_policy_id)
     }
 
     pub fn get_predefined_deno_function(name: String) -> Result<MaterializerId> {

--- a/typegraph/core/src/lib.rs
+++ b/typegraph/core/src/lib.rs
@@ -221,6 +221,14 @@ impl wit::core::Guest for Lib {
         Store::register_policy(pol.into())
     }
 
+    fn get_public_policy() -> Result<(PolicyId, String)> {
+        Ok({
+            let policy_id = Store::get_public_policy_id();
+            let policy = Store::get_policy(policy_id)?;
+            (policy_id, policy.name.clone())
+        })
+    }
+
     fn register_context_policy(key: String, check: ContextCheck) -> Result<(PolicyId, String)> {
         let name = match &check {
             ContextCheck::Value(v) => format!("__ctx_{}_{}", key, v),

--- a/typegraph/core/wit/typegraph.wit
+++ b/typegraph/core/wit/typegraph.wit
@@ -169,6 +169,9 @@ interface core {
 
     with-policy: func(data: type-policy) -> result<type-id, error>
 
+    // policy-id, policy-name
+    get-public-policy: func() -> result<tuple<policy-id, string>, error>
+
     variant context-check {
         value(string),
         pattern(string),

--- a/typegraph/deno/src/policy.ts
+++ b/typegraph/deno/src/policy.ts
@@ -9,10 +9,8 @@ export default class Policy {
   constructor(public readonly _id: number, public readonly name: string) {}
 
   static public(): Policy {
-    return Policy.create(
-      "__public",
-      runtimes.getPredefinedDenoFunc({ name: "true" }),
-    );
+    const [id, name] = core.getPublicPolicy();
+    return new Policy(id, name);
   }
 
   static context(key: string, check: string | RegExp): Policy {

--- a/typegraph/python/typegraph/policy.py
+++ b/typegraph/python/typegraph/policy.py
@@ -22,16 +22,12 @@ from typegraph.gen.exports.core import (
 from typegraph.gen.exports.core import (
     PolicySpec as WitPolicySpec,
 )
-from typegraph.gen.exports.runtimes import MaterializerDenoPredefined
-from typegraph.wit import core, runtimes, store
+from typegraph.wit import core, store
 
 
 class Policy:
     id: int
     name: str
-
-    # class attributes
-    __public: Optional["Policy"] = None
 
     def __init__(self, id: int, name: str):
         self.id = id
@@ -39,17 +35,10 @@ class Policy:
 
     @classmethod
     def public(cls):
-        res = runtimes.get_predefined_deno_func(
-            store, MaterializerDenoPredefined(name="true")
-        )
+        res = core.get_public_policy(store)
         if isinstance(res, Err):
             raise Exception(res.value)
-        mat_id = res.value
-
-        if cls.__public is None:
-            cls.__public = cls.create("__public", mat_id)
-
-        return cls.__public
+        return cls(id=res.value[0], name=res.value[1])
 
     @classmethod
     def context(cls, key: str, check: Union[str, Pattern]) -> "Policy":

--- a/website/docs/reference/changelog.mdx
+++ b/website/docs/reference/changelog.mdx
@@ -7,6 +7,43 @@ comments: false
 
 <!-- vale off -->
 
+## [v0.2.3](https://github.com/metatypedev/metatype/releases/tag/v0.2.3) (10/20/2023)
+
+<!-- Release notes generated using configuration in .github/release.yml at v0.2.3 -->
+
+### What's Changed
+
+#### New features 🎉
+
+* chore: prepare release 0.2.3-0+dev by @github-actions in [#446](https://github.com/metatypedev/metatype/pull/446)
+* feat(gate,sdk): update auth interface, better oauth2 by @afmika in [#447](https://github.com/metatypedev/metatype/pull/447)
+* fix(gate): explicit null on query arg by @afmika in [#453](https://github.com/metatypedev/metatype/pull/453)
+* feat: Remove injected fields from generated types for prisma operations by @Natoandro in [#448](https://github.com/metatypedev/metatype/pull/448)
+* chore: Upgrade wasm-opt by @Natoandro in [#456](https://github.com/metatypedev/metatype/pull/456)
+
+
+**Full Changelog**: [v0.2.2...v0.2.3](https://github.com/metatypedev/metatype/compare/v0.2.2...v0.2.3)
+
+## [v0.2.2](https://github.com/metatypedev/metatype/releases/tag/v0.2.2) (10/11/2023)
+
+<!-- Release notes generated using configuration in .github/release.yml at v0.2.2 -->
+
+### What's Changed
+
+#### New features 🎉
+
+* fix(gate): script reload while gate is running by @afmika in [#441](https://github.com/metatypedev/metatype/pull/441)
+* feat: stability fixes by @zifeo in [#442](https://github.com/metatypedev/metatype/pull/442)
+* feat(sdk): change rest queries interface by @afmika in [#444](https://github.com/metatypedev/metatype/pull/444)
+* feat: wasm + change effect none to read by @zifeo in [#443](https://github.com/metatypedev/metatype/pull/443)
+
+### Change required
+
+
+`effects.none()` has been renamed into `effects.read()` and a new shortcut is available for effect `fx` instead of `effects`.
+
+**Full Changelog**: [v0.2.1...v0.2.2](https://github.com/metatypedev/metatype/compare/v0.2.1...v0.2.2)
+
 ## [v0.2.1](https://github.com/metatypedev/metatype/releases/tag/v0.2.1) (10/5/2023)
 
 <!-- Release notes generated using configuration in .github/release.yml at v0.2.1 -->
@@ -21,7 +58,7 @@ comments: false
 
 **Full Changelog**: [v0.2.0...v0.2.1](https://github.com/metatypedev/metatype/compare/v0.2.0...v0.2.1)
 
-## [v0.2.0](https://github.com/metatypedev/metatype/releases/tag/v0.2.0) (10/4/2023)
+## [v0.2.0](https://github.com/metatypedev/metatype/releases/tag/v0.2.0) (10/5/2023)
 
 <!-- Release notes generated using configuration in .github/release.yml at v0.2.0 -->
 
@@ -82,7 +119,7 @@ comments: false
 
 **Full Changelog**: [v0.1.12...v0.1.14](https://github.com/metatypedev/metatype/compare/v0.1.12...v0.1.14)
 
-## [v0.1.12](https://github.com/metatypedev/metatype/releases/tag/v0.1.12) (8/3/2023)
+## [v0.1.12](https://github.com/metatypedev/metatype/releases/tag/v0.1.12) (8/4/2023)
 
 <!-- Release notes generated using configuration in .github/release.yml at v0.1.12 -->
 
@@ -364,7 +401,7 @@ comments: false
 
 **Full Changelog**: [v0.0.3-dev.5...v0.0.3-dev.6](https://github.com/metatypedev/metatype/compare/v0.0.3-dev.5...v0.0.3-dev.6)
 
-## [v0.0.3-dev.5](https://github.com/metatypedev/metatype/releases/tag/v0.0.3-dev.5) (2/24/2023)
+## [v0.0.3-dev.5](https://github.com/metatypedev/metatype/releases/tag/v0.0.3-dev.5) (2/25/2023)
 
 <!-- Release notes generated using configuration in .github/release.yml at v0.0.3-dev.5 -->
 
@@ -435,7 +472,7 @@ comments: false
 
 **Full Changelog**: [v0.0.3-dev.2...v0.0.3-dev.3](https://github.com/metatypedev/metatype/compare/v0.0.3-dev.2...v0.0.3-dev.3)
 
-## [v0.0.3-dev.2](https://github.com/metatypedev/metatype/releases/tag/v0.0.3-dev.2) (2/7/2023)
+## [v0.0.3-dev.2](https://github.com/metatypedev/metatype/releases/tag/v0.0.3-dev.2) (2/8/2023)
 
 <!-- Release notes generated using configuration in .github/release.yml at v0.0.3-dev.2 -->
 


### PR DESCRIPTION
The PolicyId for the public policy was cached in a class variable in `Policy`. The cache was not valid in a second typegraph defined in the same module.