### PR TITLE
fix(xtask): add support for end of flags and typechecking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7732,9 +7732,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
+checksum = "6a3211b01eea83d80687da9eef70e39d65144a3894866a5153a2723e425a157f"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -11252,18 +11252,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d135e8940b69dbee0f5b0a0be9c1cd6fa8b71d774904c13a3fcfc5dc265e43d"
+checksum = "7b09bc5df933a3dabbdb72ae4b6b71be8ae07f58774d5aa41bd20adcd41a235a"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b40efcb8258f5ca799b5590f9b5bee9f3398787b328a209f09952ffa3ed51e4"
+checksum = "3b4a14bbedb07737809c00843d1f2f88ba0b8950c114283e0387e30b1b6ee558"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -11271,8 +11271,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.37.0",
- "wasmparser 0.117.0",
+ "wasm-encoder 0.38.0",
+ "wasmparser 0.118.0",
 ]
 
 [[package]]
@@ -11356,32 +11356,31 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.117.0"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b206de0c992af9f0b51ef2fb9455623e0a19eb68f172cd8ba9cd0e46637f5ab"
+checksum = "ebbb91574de0011ded32b14db12777e7dd5e9ea2f9d7317a1ab51a9495c75924"
 dependencies = [
- "hashbrown 0.14.2",
  "indexmap 2.1.0",
  "semver 1.0.20",
 ]
 
 [[package]]
 name = "wast"
-version = "68.0.0"
+version = "69.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf3081ac6bcb3a5b72a401693b3566feb529dc2b7e7b62ea544c8a30d0f4d05"
+checksum = "efa51b5ad1391943d1bfad537e50f28fe938199ee76b115be6bae83802cd5185"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.37.0",
+ "wasm-encoder 0.38.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fabe07d22a837b3bd5662ba9e980d73de115c040923659a1801934c7ccebe49"
+checksum = "74a4c2488d058326466e086a43f5d4ea448241a8d0975e3eb0642c0828be1eb3"
 dependencies = [
  "wast",
 ]

--- a/libs/deno/src/lib.rs
+++ b/libs/deno/src/lib.rs
@@ -94,6 +94,7 @@ pub fn test_sync(
     permissions: PermissionsOptions,
     coverage_dir: Option<String>,
     custom_extensions: Arc<worker::CustomExtensionsCb>,
+    argv: Vec<String>,
 ) {
     new_thread_builder()
         .spawn(|| {
@@ -105,6 +106,7 @@ pub fn test_sync(
                         permissions,
                         coverage_dir,
                         custom_extensions,
+                        argv,
                     )
                     .await
                     .unwrap()
@@ -124,6 +126,7 @@ pub async fn test(
     permissions: PermissionsOptions,
     coverage_dir: Option<String>,
     custom_extensions: Arc<worker::CustomExtensionsCb>,
+    argv: Vec<String>,
 ) -> anyhow::Result<()> {
     use deno::tools::test::*;
 
@@ -133,7 +136,9 @@ pub async fn test(
     );
     let flags = args::Flags {
         unstable: true,
+        type_check_mode: args::TypeCheckMode::Local,
         config_flag: deno_config::ConfigFlag::Path(config_file.to_string_lossy().into()),
+        argv,
         ..Default::default()
     };
 
@@ -230,12 +235,13 @@ pub fn bench_sync(
     config_file: PathBuf,
     permissions: PermissionsOptions,
     custom_extensions: Arc<worker::CustomExtensionsCb>,
+    argv: Vec<String>,
 ) {
     new_thread_builder()
         .spawn(|| {
             create_and_run_current_thread_with_maybe_metrics(async move {
                 spawn_subcommand(async move {
-                    bench(files, config_file, permissions, custom_extensions)
+                    bench(files, config_file, permissions, custom_extensions, argv)
                         .await
                         .unwrap()
                 })
@@ -253,6 +259,7 @@ pub async fn bench(
     config_file: PathBuf,
     permissions: PermissionsOptions,
     custom_extensions: Arc<worker::CustomExtensionsCb>,
+    argv: Vec<String>,
 ) -> anyhow::Result<()> {
     use deno::tools::bench::*;
     use deno::tools::test::TestFilter;
@@ -263,7 +270,9 @@ pub async fn bench(
     );
     let flags = args::Flags {
         unstable: true,
+        type_check_mode: args::TypeCheckMode::Local,
         config_flag: deno_config::ConfigFlag::Path(config_file.to_string_lossy().into()),
+        argv,
         ..Default::default()
     };
 

--- a/libs/xtask/src/deno.rs
+++ b/libs/xtask/src/deno.rs
@@ -42,6 +42,8 @@ pub struct Test {
     /// The directory in which to put the coverage profiles
     #[clap(long)]
     coverage: Option<String>,
+    #[clap(last = true)]
+    argv: Vec<String>,
 }
 
 impl Test {
@@ -87,6 +89,7 @@ impl Test {
             permissions,
             self.coverage,
             std::sync::Arc::new(move || typegate_engine::extensions(inj.clone())),
+            self.argv,
         );
         Ok(())
     }
@@ -102,6 +105,8 @@ pub struct Bench {
     /// Path to `deno.json`
     #[clap(long)]
     config: PathBuf,
+    #[clap(last = true)]
+    argv: Vec<String>,
 }
 
 impl Bench {
@@ -144,6 +149,7 @@ impl Bench {
             self.config,
             permissions,
             std::sync::Arc::new(Vec::new),
+            self.argv,
         );
         Ok(())
     }


### PR DESCRIPTION
### Describe your change

Adds support for end of flags arguments to the `cargo x deno test/bench` commands.

### Motivation and context

Fix an issue that preventing a updating snapshots as implemented in the `dev/test.ts` script.
