### PR TITLE
feat(cli): nodejs loader

### DIFF
--- a/examples/templates/node/package.json
+++ b/examples/templates/node/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "version": "1.0.0",
   "scripts": {
-    "start": "tsx api.ts"
+    "load-tgraph": "tsx",
+    "dev": "MCLI_LOADER_CMD='npm load-tgraph' meta-cli dev"
   },
   "dependencies": {
     "@typegraph/sdk": "^0.2.4"

--- a/meta-cli/src/codegen/deno.rs
+++ b/meta-cli/src/codegen/deno.rs
@@ -506,8 +506,9 @@ mod tests {
             ));
 
             let mut event_rx = event_rx;
-            let LoaderEvent::Typegraph(tg) = event_rx.recv().await.unwrap() else {
-                bail!("error");
+            let tg = match event_rx.recv().await.unwrap() {
+                LoaderEvent::Typegraph(tg) => tg,
+                evt => bail!("unexpected loader evt: {evt:?}"),
             };
             let module_codes = Codegen::new(&tg, &typegraph_test).codegen()?;
             assert_eq!(module_codes.len(), 1);


### PR DESCRIPTION
<!--
Pull requests are squash merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog and understand when they need to update his code and how.
-->

### Describe your change

Add support for using nodejs runtime to execute and serialize typescript based typegraphs. This also adds support for `MCLI_LOADER_CMD` that can be used to override the command to exec the typegraphs.  

### Motivation and context

Previously, `meta-cli` either used the and `python` & `deno` runtimes to serialize the typegraphs. Now that `@typegraph/sdk` also supports Node.js, users might be developing in environments wher `deno` runtime is not availaible but `node` is. This PR provides a way fwd in those cases.

### Migration notes

<!-- Explain HOW users should update their code when required -->

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
