### PR TITLE
fix(ci): release changelog generation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,6 @@ Pull requests are squash merged using:
 Having a good title and description is important for the users to get readable changelog and understand when they need to update his code and how.
 -->
 
-#### Describe your change
-
 <!-- Explain WHAT the change is -->
 
 #### Motivation and context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,15 +6,15 @@ Pull requests are squash merged using:
 Having a good title and description is important for the users to get readable changelog and understand when they need to update his code and how.
 -->
 
-### Describe your change
+#### Describe your change
 
 <!-- Explain WHAT the change is -->
 
-### Motivation and context
+#### Motivation and context
 
 <!-- Explain WHY the was made or link an issue number -->
 
-### Migration notes
+#### Migration notes
 
 <!-- Explain HOW users should update their code when required -->
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v${{ env.DENO_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           makeLatest: true
           bodyFile: "CHANGE.md"
           discussionCategory: "Announcements"
+          prerelease: ${{ contains(github.ref_name, 'dev') || contains(github.ref_name, 'alpha') }}
 
   meta-cli:
     needs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,12 +108,7 @@ jobs:
           key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock', '.ghjk/lock.json') }}
       - shell: bash
         run: |
-          env
-          which python3
-          python3 --version
           python3 -m venv .venv
-          ls .venv
-          ls .venv/bin
           source .venv/bin/activate
           poetry install --no-root
           cd website

--- a/cliff.toml
+++ b/cliff.toml
@@ -55,7 +55,7 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
-  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/metatypedev/metatype/pull/${2}))"},
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "(<a href=\"https://github.com/metatypedev/metatype/pull/526\">#${2}</a>)"},
 ]
 commit_parsers = [
   { message = "^feat", group = "Features" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -55,7 +55,7 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
-  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "(<a href=\"https://github.com/metatypedev/metatype/pull/526\">#${2}</a>)"},
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "(<a href=\"https://github.com/metatypedev/metatype/pull/${2}\">#${2}</a>)"},
 ]
 commit_parsers = [
   { message = "^feat", group = "Features" },


### PR DESCRIPTION
#### Describe your change

Configures the `checkout` action step in the workflow that generates the workflow to clone the full git history.

#### Motivation and context

The updates to the release workflow that introduce [git cliff](https://git-cliff.org/) based changelogs (back in #487) don't appear to be in effect.

#### Migration notes

No end user changes required.

#### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
