### PR TITLE
fix(ci): bug in `typegraph` release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           cd ../..
 
           npm install --global @bytecodealliance/jco@$JCO_VERSION
-          jco transpile $WASM_FILE -o typegraph/node/src/gen
+          jco transpile $WASM_FILE -o typegraph/node/sdk/src/gen
 
           cd typegraph/node
           pnpm install


### PR DESCRIPTION
#### Motivation and context

`jco` output path is wrong.

#### Migration notes

N/A

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
