### PR TITLE
refactor(ci): `workflow_dispatch` for release wflow

### DIFF
--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -348,6 +348,24 @@
           },
           "portRef": "cpy_bs_ghrel@0.1.0",
           "releaseTag": "20231002"
+        },
+        "f18f86e2e763848312dd0dc70b5088ea5b0f70f08a3566d0e2120100db7e9a90": {
+          "version": "0.14.2",
+          "depConfigs": {
+            "node_org": {
+              "version": "v21.5.0",
+              "depConfigs": {
+                "tar_aa": {
+                  "version": "1.34",
+                  "depConfigs": {},
+                  "portRef": "tar_aa@0.1.0"
+                }
+              },
+              "portRef": "node_org@0.1.0"
+            }
+          },
+          "portRef": "npmi_npm@0.1.0",
+          "packageName": "@bytecodealliance/jco"
         }
       }
     },
@@ -679,7 +697,7 @@
               "installType": "version"
             },
             {
-              "version": "0.12.1",
+              "version": "0.14.2",
               "port": {
                 "ty": "denoWorker@v1",
                 "name": "npmi_npm",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
         required: true
         type: boolean
         default: true
+      checkBump:
+        description: check-bump adds a release entry to github so it's disabled by default.
+        required: true
+        type: boolean
+        default: false
   push:
       tags:
         - v*
@@ -18,20 +23,25 @@ env:
 jobs:
   check-bump:
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag'
-
+    if: github.ref_type == 'tag' 
+      && (
+        github.event_name != 'workflow_dispatch'
+        inputs.checkBump
+      )
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
+        id: latest-tag
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v${{ env.DENO_VERSION }}
       - uses: kenji-miyake/setup-git-cliff@v2
       - run: |
           VERSION=$(deno run -A dev/lock.ts --version)
-          if [[ "${{ github.ref_name }}" != "v$VERSION" ]]; then
-            echo "Tag ${{ github.ref_name }} does not match code version v$VERSION, stopping."
+          if [[ "${{ steps.latest-tag.outputs.tag }}" != "v$VERSION" ]]; then
+            echo "Tag ${{ steps.latest-tag.outputs.tag }} does not match code version v$VERSION, stopping."
             exit -1
           fi
           echo "Releasing v$VERSION"
@@ -39,15 +49,24 @@ jobs:
           cat CHANGE.md
       - uses: ncipollo/release-action@v1
         with:
-          tag: ${{ github.ref_name }}
+          tag: ${{ steps.latest-tag.outputs.tag }}
           makeLatest: true
           bodyFile: "CHANGE.md"
           discussionCategory: "Announcements"
-          prerelease: ${{ contains(github.ref_name, 'dev') || contains(github.ref_name, 'alpha') }}
+          prerelease: ${{ contains(steps.latest-tag.outputs.tag 'dev') || contains(steps.latest-tag.outputs.tag 'alpha') }}
 
   meta-cli:
     needs:
       - check-bump
+    # using `always()` makes the job evaulte despite
+    # status of check-bump
+    # we combine that with our own conditions
+    if: |
+      always()
+      && (
+        needs.check-bump.result == 'success'
+        || github.event_name == 'workflow_dispatch'
+      )
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
@@ -70,6 +89,10 @@ jobs:
             suffix: ""
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
+        id: latest-tag
       - uses: dsherret/rust-toolchain-file@v1
         with:
           targets: ${{ matrix.target }}
@@ -88,20 +111,30 @@ jobs:
           args: "--locked --release --package meta-cli --target ${{ matrix.target }}"
       - run: |
           cd target/${{ matrix.target }}/release
-          tar czvf ../../../meta-cli-${{ github.ref_name }}-${{ matrix.target }}.tar.gz "meta${{ matrix.suffix }}"
+          tar czvf ../../../meta-cli-${{ steps.latest-tag.outputs.tag }}-${{ matrix.target }}.tar.gz "meta${{ matrix.suffix }}"
       - uses: svenstaro/upload-release-action@v2
         with:
-          tag: ${{ github.ref }}
-          file: "meta-cli-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
-          asset_name: "meta-cli-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
+          tag: ${{ steps.latest-tag.outputs.tag }}
+          file: "meta-cli-${{ steps.latest-tag.outputs.tag }}-${{ matrix.target }}.tar.gz"
+          asset_name: "meta-cli-${{ steps.latest-tag.outputs.tag }}-${{ matrix.target }}.tar.gz"
           overwrite: ${{ inputs.ovewriteArtifacts }}
 
   typegraph:
     needs:
       - check-bump
+    if: |
+      always()
+      && (
+        needs.check-bump.result == 'success'
+        || github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
+        id: latest-tag
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
         with:
@@ -144,7 +177,7 @@ jobs:
           pnpm publish --no-git-checks
       - uses: svenstaro/upload-release-action@v2
         with:
-          tag: ${{ github.ref }}
+          tag: ${{ steps.latest-tag.outputs.tag }}
           file: "typegraph/python/dist/*"
           file_glob: true
           overwrite: ${{ inputs.ovewriteArtifacts }}
@@ -152,6 +185,12 @@ jobs:
   typegate:
     needs:
       - check-bump
+    if: |
+      always()
+      && (
+        needs.check-bump.result == 'success'
+        || github.event_name == 'workflow_dispatch'
+      )
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -191,8 +230,16 @@ jobs:
   docker:
     needs:
       - typegate
+    # needs hack required here as well because
+    # `typegate` uses it
+    if: always() && needs.typegate.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
+        id: latest-tag
       - uses: actions/download-artifact@v4
         with:
           name: digests
@@ -205,15 +252,25 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           cd ./digests
-          docker buildx imagetools create --tag ${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }} --tag ${{ env.REGISTRY_IMAGE }}:latest $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          docker buildx imagetools create --tag ${{ env.REGISTRY_IMAGE }}:${{ steps.latest-tag.outputs.tag }} --tag ${{ env.REGISTRY_IMAGE }}:latest $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:latest
 
   vscode-extension:
-    # needs:
-    #   - check-bump
+    needs:
+      - check-bump
+    if: |
+      always()
+      && (
+        needs.check-bump.result == 'success'
+        || github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
+        id: latest-tag
       - uses: metatypedev/setup-ghjk@a4453d20156edde8e1c9b19784f8188a36b3bf23
       - shell: bash
         run: |
@@ -230,7 +287,7 @@ jobs:
           pnpm run publish -p $${ env.AZURE_DEVOPS_TOKEN }
       - uses: svenstaro/upload-release-action@v2
         with:
-          tag: ${{ github.ref }}
+          tag: ${{ steps.latest-tag.outputs.tag }}
           file: "dev-tools/*.vsix"
           file_glob: true
           overwrite: ${{ inputs.ovewriteArtifacts }}
@@ -244,6 +301,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dsherret/rust-toolchain-file@v1
       - uses: denoland/setup-deno@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.ref_type == 'tag' 
       && (
         github.event_name != 'workflow_dispatch'
-        inputs.checkBump
+        || inputs.checkBump
       )
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,14 @@
 on:
+  workflow_dispatch:
+    inputs:
+      ovewriteArtifacts:
+        description: Ovewrite artifacts on the release.
+        required: true
+        type: boolean
+        default: true
   push:
-    tags:
-      - v*
+      tags:
+        - v*
 
 env:
   GHJK_VERSION: "7bef036"
@@ -87,7 +94,7 @@ jobs:
           tag: ${{ github.ref }}
           file: "meta-cli-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
           asset_name: "meta-cli-${{ github.ref_name }}-${{ matrix.target }}.tar.gz"
-          overwrite: false
+          overwrite: ${{ inputs.ovewriteArtifacts }}
 
   typegraph:
     needs:
@@ -140,7 +147,7 @@ jobs:
           tag: ${{ github.ref }}
           file: "typegraph/python/dist/*"
           file_glob: true
-          overwrite: false
+          overwrite: ${{ inputs.ovewriteArtifacts }}
 
   typegate:
     needs:
@@ -202,14 +209,12 @@ jobs:
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:latest
 
   vscode-extension:
-    needs:
-      - check-bump
+    # needs:
+    #   - check-bump
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: ${{ env.DENO_VERSION }}
+      - uses: metatypedev/setup-ghjk@a4453d20156edde8e1c9b19784f8188a36b3bf23
       - shell: bash
         run: |
           cd dev-tools
@@ -228,7 +233,7 @@ jobs:
           tag: ${{ github.ref }}
           file: "dev-tools/*.vsix"
           file_glob: true
-          overwrite: false
+          overwrite: ${{ inputs.ovewriteArtifacts }}
 
   bump:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
   check-bump:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' 
-      && (
-        github.event_name != 'workflow_dispatch'
-        || inputs.checkBump
+      || (
+        github.event_name == 'workflow_dispatch'
+        && inputs.checkBump
       )
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,8 +73,6 @@ jobs:
       - uses: metatypedev/setup-ghjk@a4453d20156edde8e1c9b19784f8188a36b3bf23
       - shell: bash
         run: |
-          env
-          ls -osha $LIBCLANG_PATH
           sudo apt update
           sudo apt install -y --no-install-recommends libclang-dev clang
           cd website


### PR DESCRIPTION

- Manual trigger for release wflow
- Adds missing ghjk step for `vscode-extension` release job

#### Motivation and context

Provides recovery path for when things break.

#### Migration notes

Doesn't affect end users.

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
