### PR TITLE
fix(ci): typo in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           makeLatest: true
           bodyFile: "CHANGE.md"
           discussionCategory: "Announcements"
-          prerelease: ${{ contains(steps.latest-tag.outputs.tag 'dev') || contains(steps.latest-tag.outputs.tag 'alpha') }}
+          prerelease: ${{ contains(steps.latest-tag.outputs.tag, 'dev') || contains(steps.latest-tag.outputs.tag, 'alpha') }}
 
   meta-cli:
     needs:


### PR DESCRIPTION
Fix small typo. Surprised `act` didn't catch this, it must evaluate expressions lazily.
