### PR TITLE
fix(ci): typos in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           cd typegraph/python
           poetry install
           poetry build
-          [ $${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
+          [ ${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
             && poetry publish --skip-existing \
             || poetry publish
           cd ../..
@@ -176,7 +176,7 @@ jobs:
 
           cd typegraph/node/sdk/dist
           pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
-          [ $${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
+          [ ${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
             && pnpm publish --no-git-checks --force \
             || pnpm publish --no-git-checks
       - uses: svenstaro/upload-release-action@v2
@@ -289,9 +289,9 @@ jobs:
           pnpm compile:vscode
           pnpm vscode:package
           
-          [ $${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
-            && pnpm run vscode:publish -p $${ env.AZURE_DEVOPS_TOKEN } --skip-duplicate \
-            || pnpm run vscode:publish -p $${ env.AZURE_DEVOPS_TOKEN } 
+          [ ${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
+            && pnpm run vscode:publish -p ${{ env.AZURE_DEVOPS_TOKEN }} --skip-duplicate \
+            || pnpm run vscode:publish -p ${{ env.AZURE_DEVOPS_TOKEN }} 
       - uses: svenstaro/upload-release-action@v2
         with:
           tag: ${{ steps.latest-tag.outputs.tag }}


### PR DESCRIPTION
Oof, I can't believe I missed these. The publish steps are hard to test locally with `act` so ig they require extra scrutiny.

#### Motivation and context

Bug on manual dispatch of `releasae` wflow.
