### PR TITLE
fix(ci): mismatch in location of `$AZURE_DEVOPS_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,8 +290,8 @@ jobs:
           pnpm vscode:package
           
           [ ${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
-            && pnpm run vscode:publish -p ${{ env.AZURE_DEVOPS_TOKEN }} --skip-duplicate \
-            || pnpm run vscode:publish -p ${{ env.AZURE_DEVOPS_TOKEN }} 
+            && pnpm run vscode:publish -p ${{ secrets.AZURE_DEVOPS_TOKEN }} --skip-duplicate \
+            || pnpm run vscode:publish -p ${{ secrets.AZURE_DEVOPS_TOKEN }} 
       - uses: svenstaro/upload-release-action@v2
         with:
           tag: ${{ steps.latest-tag.outputs.tag }}


### PR DESCRIPTION
Another minor issue with the release workflow.

#### Motivation and context

Failure in release run [here](https://github.com/metatypedev/metatype/actions/runs/7521755432/job/20472963653).
