### PR TITLE
feat: flattened context

### DIFF
--- a/typegate/src/services/auth/mod.ts
+++ b/typegate/src/services/auth/mod.ts
@@ -50,14 +50,17 @@ export function initAuth(
   }
 }
 
+export type ProfileClaims = {
+  [key: `profile.${string}`]: unknown;
+};
+
 export type JWTClaims = {
   provider: string;
   accessToken: string;
   refreshToken: string;
   refreshAt: number;
-  profile: null | Record<string, unknown>;
   scope?: string[];
-};
+} & ProfileClaims;
 
 export async function ensureJWT(
   request: Request,
@@ -71,9 +74,9 @@ export async function ensureJWT(
     return [{}, headers];
   }
 
-  let auth = null;
+  let auth: Protocol | null = null;
   if (kind.toLowerCase() === "basic") {
-    auth = engine.tg.auths.get("basic");
+    auth = engine.tg.auths.get("basic") ?? null;
   } else {
     try {
       const { provider } = await unsafeExtractJWT(token);
@@ -81,7 +84,7 @@ export async function ensureJWT(
         // defaulting to first auth
         auth = engine.tg.auths.values().next().value;
       } else {
-        auth = engine.tg.auths.get(provider as string);
+        auth = engine.tg.auths.get(provider as string) ?? null;
       }
     } catch (e) {
       logger.warning(`malformed jwt: ${e}`);

--- a/typegate/tests/auth/auth_test.ts
+++ b/typegate/tests/auth/auth_test.ts
@@ -177,7 +177,7 @@ Meta.test("Auth", async (t) => {
     const { token } = JSON.parse(await decrypt(cook!));
     const claims = await verifyJWT(token) as JWTClaims;
     assertEquals(claims.accessToken, accessToken);
-    assertEquals(claims.profile?.id, id);
+    assertEquals(claims["profile.id"], id);
     assertEquals(await decrypt(claims.refreshToken as string), refreshToken);
   });
 
@@ -262,7 +262,7 @@ Meta.test("Auth", async (t) => {
       accessToken: "a1",
       refreshToken: "r1",
       refreshAt: new Date().valueOf() + 10,
-      profile: {},
+      "profile.id": 123,
     };
     const jwt = await signJWT(claims, 10);
     await gql`
@@ -292,7 +292,7 @@ Meta.test("Auth", async (t) => {
       accessToken: "a1",
       refreshToken,
       refreshAt: Math.floor(new Date().valueOf() / 1000),
-      profile: {},
+      "profile.id": 123,
     };
     const jwt = await signJWT(claims, 10);
     await sleep(1);
@@ -359,7 +359,7 @@ Meta.test("Auth", async (t) => {
       accessToken: "a1",
       refreshToken: "r1",
       refreshAt: Math.floor(new Date().valueOf() / 1000),
-      profile: {},
+      "profile.id": 123,
     };
     const jwt = await signJWT(claims, 10);
     await sleep(1);

--- a/typegraph/python/typegraph/graph/params.py
+++ b/typegraph/python/typegraph/graph/params.py
@@ -28,7 +28,7 @@ class ExtendedProfiler(StdOauth2Profiler):
 
 @dataclass
 class CustomProfiler(StdOauth2Profiler):
-    id: "t.func"
+    func: "t.func"
 
 
 class Rate:
@@ -211,7 +211,7 @@ class RawAuth:
             )
         elif isinstance(profiler, CustomProfiler):
             res = wit_utils.oauth2_with_custom_profiler(
-                store, service, scopes, profiler.id
+                store, service, scopes, profiler.func.id
             )
         else:  # default profiler
             res = wit_utils.oauth2(store, service, scopes)


### PR DESCRIPTION
Flatten profile fields in the context.

So instead of
```js
{
    provider: 'github',
    accessToken: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
    refreshToken: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
    refreshAt: 1704717676,
    profile: { id: '43663718' },
    exp: 1707280877,
    iat: 1704688876
}
```

we would have:
```js
{
    provider: 'github',
    accessToken: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
    refreshToken: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
    refreshAt: 1704717676,
    'profile.id': '43663718',
    exp: 1707280877,
    iat: 1704688876
 }
```

#### Motivation and context

It was impossible to get the nested id into a `from_context` injection.
Now we can inject `.from_context("profile.id")`.

#### Migration notes

<!-- Explain HOW users should update their code when required -->

### Checklist

- [ ] The change come with new or modified tests
- [x] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
