### PR TITLE
feat(prisma): Add support multi-field ids and id on struct

### DIFF
--- a/dev/deps.ts
+++ b/dev/deps.ts
@@ -23,3 +23,6 @@ export * as semver from "https://deno.land/std@0.202.0/semver/mod.ts";
 // export { udd } from "https://deno.land/x/udd@0.8.2/mod.ts";
 export { udd } from "https://github.com/levibostian/deno-udd/raw/ignore-prerelease/mod.ts";
 export * as dnt from "https://deno.land/x/dnt@0.38.1/mod.ts";
+// @deno-types="https://deno.land/x/fuse@v6.4.1/dist/fuse.d.ts"
+import Fuse from "https://deno.land/x/fuse@v6.4.1/dist/fuse.esm.min.js";
+export { Fuse };

--- a/libs/common/src/typegraph/runtimes/prisma.rs
+++ b/libs/common/src/typegraph/runtimes/prisma.rs
@@ -130,6 +130,7 @@ pub struct Model {
     pub type_name: String,
     pub props: Vec<Property>,
     pub id_fields: Vec<String>,
+    pub unique_constraints: Vec<Vec<String>>,
 }
 
 #[cfg_attr(feature = "codegen", derive(JsonSchema))]

--- a/typegate/src/typegraph/types.ts
+++ b/typegate/src/typegraph/types.ts
@@ -407,6 +407,7 @@ export interface Model {
   typeName: string;
   props: Property[];
   idFields: string[];
+  uniqueConstraints: string[][];
 }
 export interface ManagedInjection {
   create?: Injection2 | null;

--- a/typegate/tests/runtimes/prisma/full_prisma_mapping.py
+++ b/typegate/tests/runtimes/prisma/full_prisma_mapping.py
@@ -50,10 +50,10 @@ def prisma(g: Graph):
 
     extended_profile = t.struct(
         {
-            "id": t.integer(as_id=True),
             "bio": t.string(),
             "user": g.ref("User"),
         },
+        config={"id": ["user"]},
         name="ExtendedProfile",
     )
 

--- a/typegate/tests/runtimes/prisma/full_prisma_mapping_test.ts
+++ b/typegate/tests/runtimes/prisma/full_prisma_mapping_test.ts
@@ -41,7 +41,7 @@ Meta.test("prisma full mapping", async (t) => {
                 }
               }
               extended_profile: {
-                create: { id: 10111, bio: "Some bio 1" }
+                create: { bio: "Some bio 1" }
               }
             }
           ) 
@@ -739,7 +739,6 @@ Meta.test("prisma full mapping", async (t) => {
         ) {
           id
           extended_profile {
-            id
             bio
           }
         }

--- a/typegate/tests/runtimes/prisma/schema_generation.py
+++ b/typegate/tests/runtimes/prisma/schema_generation.py
@@ -467,7 +467,31 @@ def multi_field_id(g: Graph):
 
 @typegraph()
 def foreign_id(g: Graph):
-    pass
+    db = PrismaRuntime("test", "POSTGRES")
+
+    user = t.struct(
+        {
+            "id": t.uuid(as_id=True, config=["auto"]),
+            "email": t.email(config=["unique"]),
+            "profile": g.ref("Profile").optional(),
+        },
+        name="User",
+    )
+
+    _profile = t.struct(
+        {
+            "user": user,
+            "profilePicUrl": t.uri(),
+            "bio": t.string().optional(),
+        },
+        name="Profile",
+        config={"id": ["user"]},
+    )
+
+    g.expose(
+        createUser=db.create(user),
+        # createProfile=db.create(profile),
+    )
 
 
 @typegraph()

--- a/typegate/tests/runtimes/prisma/schema_generation.py
+++ b/typegate/tests/runtimes/prisma/schema_generation.py
@@ -445,3 +445,36 @@ def injection(g: Graph):
     g.expose(
         createUser=db.create(user),
     )
+
+
+@typegraph()
+def multi_field_id(g: Graph):
+    db = PrismaRuntime("test", "POSTGRES")
+
+    project = t.struct(
+        {
+            "ownerName": t.string(),
+            "name": t.string(),
+            "description": t.string().optional(),
+        },
+        config={"id": ["ownerName", "name"]},
+    ).rename("Project")
+
+    g.expose(
+        createProject=db.create(project),
+    )
+
+
+@typegraph()
+def foreign_id(g: Graph):
+    pass
+
+
+@typegraph()
+def mixed_id(g: Graph):
+    pass
+
+
+@typegraph()
+def multi_field_unique(g: Graph):
+    pass

--- a/typegate/tests/runtimes/prisma/schema_generation.py
+++ b/typegate/tests/runtimes/prisma/schema_generation.py
@@ -490,15 +490,29 @@ def foreign_id(g: Graph):
 
     g.expose(
         createUser=db.create(user),
-        # createProfile=db.create(profile),
     )
 
 
 @typegraph()
-def mixed_id(g: Graph):
-    pass
-
-
-@typegraph()
 def multi_field_unique(g: Graph):
-    pass
+    db = PrismaRuntime("test", "POSTGRES")
+
+    account = t.struct(
+        {
+            "id": t.uuid(as_id=True, config=["auto"]),
+            "projects": t.list(g.ref("Project")),
+        }
+    ).rename("Account")
+
+    _project = t.struct(
+        {
+            "id": t.uuid(as_id=True, config=["auto"]),
+            "owner": g.ref("Account"),
+            "name": t.string(),
+        },
+        config={"unique": [["owner", "name"]]},
+    ).rename("Project")
+
+    g.expose(
+        createAccount=db.create(account),
+    )

--- a/typegate/tests/runtimes/prisma/schema_generation_test.ts
+++ b/typegate/tests/runtimes/prisma/schema_generation_test.ts
@@ -173,7 +173,7 @@ Meta.test("schema generation", async (t) => {
               user User @relation(name: "userProfile", fields: [userId], references: [id])
               userId Int
   
-              @@unique(userId)
+              @@unique([userId])
           }
         `,
       );
@@ -191,7 +191,7 @@ Meta.test("schema generation", async (t) => {
               user User @relation(name: "__rel_Profile_User_1", fields: [userId], references: [id])
               userId Int
       
-              @@unique(userId)
+              @@unique([userId])
           }
         `,
       );
@@ -204,7 +204,7 @@ Meta.test("schema generation", async (t) => {
               user User @relation(name: "__rel_Profile_User_1", fields: [userId], references: [id])
               userId Int
       
-              @@unique(userId)
+              @@unique([userId])
           }
       
           model User {
@@ -233,7 +233,7 @@ Meta.test("schema generation", async (t) => {
               user User? @relation(name: "__rel_Profile_User_1", fields: [userId], references: [id])
               userId Int?
   
-              @@unique(userId)
+              @@unique([userId])
           }
         `,
       );
@@ -246,7 +246,7 @@ Meta.test("schema generation", async (t) => {
               user User? @relation(name: "__rel_Profile_User_1", fields: [userId], references: [id])
               userId Int?
   
-              @@unique(userId)
+              @@unique([userId])
           }
 
           model User {
@@ -275,7 +275,7 @@ Meta.test("schema generation", async (t) => {
               user User @relation(name: "userProfile", fields: [userId], references: [id])
               userId Int
   
-              @@unique(userId)
+              @@unique([userId])
           }
         `,
       );
@@ -293,7 +293,7 @@ Meta.test("schema generation", async (t) => {
               user User @relation(name: "userProfile", fields: [userId], references: [id])
               userId Int
   
-              @@unique(userId)
+              @@unique([userId])
           }
         `,
       );
@@ -306,7 +306,7 @@ Meta.test("schema generation", async (t) => {
               user User @relation(name: "userProfile", fields: [userId], references: [id])
               userId Int
   
-              @@unique(userId)
+              @@unique([userId])
           }
 
           model User {
@@ -382,7 +382,7 @@ Meta.test("schema generation", async (t) => {
             nextId String? @db.Uuid
             prev ListNode? @relation(name: "__rel_ListNode_ListNode_1")
   
-            @@unique(nextId)
+            @@unique([nextId])
         }
       `,
     );
@@ -396,7 +396,7 @@ Meta.test("schema generation", async (t) => {
             next ListNode? @relation(name: "__rel_ListNode_ListNode_1", fields: [nextId], references: [id])
             nextId String? @db.Uuid
   
-            @@unique(nextId)
+            @@unique([nextId])
         }
       `,
     );
@@ -464,7 +464,7 @@ Meta.test("schema generation", async (t) => {
               motherId String? @db.Uuid
               children Person[] @relation(name: "__rel_Person_Person_2")
       
-              @@unique(personal_heroId)
+              @@unique([personal_heroId])
           }
         `,
       );
@@ -512,14 +512,14 @@ Meta.test("schema generation", async (t) => {
             id String @db.Uuid @default(uuid()) @id
             email String @db.Text @unique
             profile Profile? @relation(name: "__rel_Profile_User_1")
-        } 
+        }
 
         model Profile {
             user User @relation(name: "__rel_Profile_User_1", fields: [userId], references: [id])
             userId String @db.Uuid @id
             profilePicUrl String @db.Text
             bio String? @db.Text
-        } 
+        }
       `,
     );
   });

--- a/typegate/tests/runtimes/prisma/schema_generation_test.ts
+++ b/typegate/tests/runtimes/prisma/schema_generation_test.ts
@@ -488,4 +488,19 @@ Meta.test("schema generation", async (t) => {
       );
     },
   );
+
+  await t.should("generate with multi-field id", async () => {
+    await assertGeneratedSchema(
+      "multi-field-id",
+      outdent`
+        model Project {
+            ownerName String @db.Text
+            name String @db.Text
+            description String? @db.Text
+
+            @@id([ownerName, name])
+        }
+      `,
+    );
+  });
 });

--- a/typegate/tests/runtimes/prisma/schema_generation_test.ts
+++ b/typegate/tests/runtimes/prisma/schema_generation_test.ts
@@ -512,13 +512,34 @@ Meta.test("schema generation", async (t) => {
             id String @db.Uuid @default(uuid()) @id
             email String @db.Text @unique
             profile Profile? @relation(name: "__rel_Profile_User_1")
-        }
+        } 
 
         model Profile {
             user User @relation(name: "__rel_Profile_User_1", fields: [userId], references: [id])
             userId String @db.Uuid @id
             profilePicUrl String @db.Text
             bio String? @db.Text
+        } 
+      `,
+    );
+  });
+
+  await t.should("generate with multi-field unique constraint", async () => {
+    await assertGeneratedSchema(
+      "multi-field-unique",
+      outdent`
+        model Account {
+            id String @db.Uuid @default(uuid()) @id
+            projects Project[] @relation(name: "__rel_Project_Account_1")
+        }
+
+        model Project {
+            id String @db.Uuid @default(uuid()) @id
+            owner Account @relation(name: "__rel_Project_Account_1", fields: [ownerId], references: [id])
+            ownerId String @db.Uuid
+            name String @db.Text
+
+            @@unique([ownerId, name])
         }
       `,
     );

--- a/typegate/tests/runtimes/prisma/schema_generation_test.ts
+++ b/typegate/tests/runtimes/prisma/schema_generation_test.ts
@@ -503,4 +503,24 @@ Meta.test("schema generation", async (t) => {
       `,
     );
   });
+
+  await t.should("generate with foreign id", async () => {
+    await assertGeneratedSchema(
+      "foreign-id",
+      outdent`
+        model User {
+            id String @db.Uuid @default(uuid()) @id
+            email String @db.Text @unique
+            profile Profile? @relation(name: "__rel_Profile_User_1")
+        }
+
+        model Profile {
+            user User @relation(name: "__rel_Profile_User_1", fields: [userId], references: [id])
+            userId String @db.Uuid @id
+            profilePicUrl String @db.Text
+            bio String? @db.Text
+        }
+      `,
+    );
+  });
 });

--- a/typegraph/core/src/runtimes/prisma/constraints.rs
+++ b/typegraph/core/src/runtimes/prisma/constraints.rs
@@ -70,7 +70,7 @@ fn find_id_part_fields(
 
 fn find_struct_level_ids(
     type_name: &str,
-    config: RuntimeConfig<'_>,
+    config: &RuntimeConfig<'_>,
     props: &IndexMap<String, Property>,
 ) -> Result<Option<Vec<String>>> {
     let id_config: Option<Vec<String>> = config.get("id").ok().flatten();
@@ -139,7 +139,7 @@ fn find_struct_level_ids(
 pub fn find_id_fields(
     type_name: &str,
     props: &IndexMap<String, Property>,
-    config: RuntimeConfig<'_>,
+    config: &RuntimeConfig<'_>,
 ) -> Result<Vec<String>> {
     let as_id_field = find_as_id_field(type_name, props)?;
     let id_part_fields = find_id_part_fields(type_name, props)?;
@@ -154,4 +154,23 @@ pub fn find_id_fields(
             .to_string()
             .into()),
     }
+}
+
+pub fn get_struct_level_unique_constraints(
+    type_name: &str,
+    config: &RuntimeConfig<'_>,
+) -> Result<Vec<Vec<String>>> {
+    let unique_config: Option<Vec<Vec<String>>> = config.get("unique").ok().flatten();
+
+    let Some(unique_config) = unique_config else {
+        return Ok(vec![]);
+    };
+
+    for unique_fields in &unique_config {
+        if unique_fields.is_empty() {
+            return Err(format!("unexpected empty unique constraint in model {type_name}").into());
+        }
+    }
+
+    Ok(unique_config)
 }

--- a/typegraph/core/src/runtimes/prisma/context.rs
+++ b/typegraph/core/src/runtimes/prisma/context.rs
@@ -303,6 +303,7 @@ impl PrismaContext {
                 .filter_map(|r| r.transpose())
                 .collect::<Result<Vec<_>>>()?,
             id_fields: model.id_fields.clone(),
+            unique_constraints: model.unique_constraints.clone(),
         })
     }
 

--- a/typegraph/core/src/runtimes/prisma/context.rs
+++ b/typegraph/core/src/runtimes/prisma/context.rs
@@ -302,7 +302,7 @@ impl PrismaContext {
                 })
                 .filter_map(|r| r.transpose())
                 .collect::<Result<Vec<_>>>()?,
-            id_fields: vec![model.id_field.clone()],
+            id_fields: model.id_fields.clone(),
         })
     }
 

--- a/typegraph/core/src/runtimes/prisma/id_fields.rs
+++ b/typegraph/core/src/runtimes/prisma/id_fields.rs
@@ -1,0 +1,157 @@
+// Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
+// SPDX-License-Identifier: MPL-2.0
+
+pub use common::typegraph::runtimes::prisma::{ScalarType, StringType};
+use indexmap::IndexMap;
+
+use crate::errors::Result;
+use crate::runtimes::prisma::errors;
+use crate::runtimes::prisma::relationship::Cardinality;
+use crate::runtimes::prisma::type_utils::RuntimeConfig;
+use crate::types::TypeDefExt;
+
+use super::model::Property;
+
+fn find_as_id_field(type_name: &str, props: &IndexMap<String, Property>) -> Result<Option<String>> {
+    let as_id_fields = props
+        .iter()
+        .filter_map(|(k, p)| match p {
+            Property::Scalar(prop) => match prop.quantifier {
+                Cardinality::One => prop
+                    .type_id
+                    .as_type_def()
+                    .unwrap()
+                    .unwrap()
+                    .base()
+                    .as_id
+                    .then(|| k.clone()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    match as_id_fields.len() {
+        0..=1 => Ok(as_id_fields.into_iter().next()),
+        _ => Err(errors::multiple_id_fields(type_name)),
+    }
+}
+
+fn find_id_part_fields(
+    type_name: &str,
+    props: &IndexMap<String, Property>,
+) -> Result<Option<Vec<String>>> {
+    let id_part_fields = props
+        .iter()
+        .filter_map(|(k, p)| match p {
+            Property::Scalar(prop) => match prop.quantifier {
+                Cardinality::One => {
+                    let typedef = prop.type_id.as_type_def().unwrap().unwrap();
+                    let runtime_config = RuntimeConfig::new(typedef.base().runtime_config.as_ref());
+                    let id_part = runtime_config
+                        .get("id_part")
+                        .ok()
+                        .flatten()
+                        .unwrap_or(false);
+                    id_part.then(|| k.clone())
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    match id_part_fields.len() {
+        0 => Ok(None),
+        1 => Err(format!("expected more than one id_part fields on the model {type_name}").into()),
+        _ => Ok(Some(id_part_fields)),
+    }
+}
+
+fn find_struct_level_ids(
+    type_name: &str,
+    config: RuntimeConfig<'_>,
+    props: &IndexMap<String, Property>,
+) -> Result<Option<Vec<String>>> {
+    let id_config: Option<Vec<String>> = config.get("id").ok().flatten();
+
+    let Some(id_config) = id_config else {
+        return Ok(None);
+    };
+
+    if id_config.is_empty() {
+        return Err("id config must not be empty".into());
+    }
+
+    for id_field in &id_config {
+        let prop = props
+            .get(id_field)
+            .ok_or_else(|| format!("id field {} not found", id_field))?;
+        match prop {
+            Property::Scalar(prop) => match prop.quantifier {
+                Cardinality::One => continue,
+                Cardinality::Optional => {
+                    return Err(format!(
+                        "id field {} must not be optional in model {type_name}",
+                        id_field
+                    )
+                    .into())
+                }
+                Cardinality::Many => {
+                    return Err(format!(
+                        "id field {} must not be a list in model {type_name}",
+                        id_field
+                    )
+                    .into())
+                }
+            },
+            Property::Model(prop) => match prop.quantifier {
+                Cardinality::One => continue,
+                Cardinality::Optional => {
+                    return Err(format!(
+                        "id field {} must not be optional in model {type_name}",
+                        id_field
+                    )
+                    .into())
+                }
+                Cardinality::Many => {
+                    return Err(format!(
+                        "id field {} must not be a list in model {type_name}",
+                        id_field
+                    )
+                    .into())
+                }
+            },
+            Property::Unmanaged(_) => {
+                // TODO
+                return Err(format!(
+                    "unexpected id on unmanaged field {} in model {type_name}",
+                    id_field
+                )
+                .into());
+            }
+        }
+    }
+
+    Ok(Some(id_config))
+}
+
+pub fn find_id_fields(
+    type_name: &str,
+    props: &IndexMap<String, Property>,
+    config: RuntimeConfig<'_>,
+) -> Result<Vec<String>> {
+    let as_id_field = find_as_id_field(type_name, props)?;
+    let id_part_fields = find_id_part_fields(type_name, props)?;
+    let struct_id_fields = find_struct_level_ids(type_name, config, props)?;
+
+    match (as_id_field, id_part_fields, struct_id_fields) {
+        (None, None, None) => Err(errors::id_field_not_found(type_name)),
+        (Some(as_id_field), None, None) => Ok(vec![as_id_field]),
+        (None, Some(id_part_fields), None) => Ok(id_part_fields),
+        (None, None, Some(struct_id_fields)) => Ok(struct_id_fields),
+        (_, _, _) => Err("id_part, as_id and struct-level ids are mutually exclusive"
+            .to_string()
+            .into()),
+    }
+}

--- a/typegraph/core/src/runtimes/prisma/mod.rs
+++ b/typegraph/core/src/runtimes/prisma/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod context;
 pub mod errors;
+mod id_fields;
 pub mod migration;
 mod model;
 pub mod relationship;

--- a/typegraph/core/src/runtimes/prisma/mod.rs
+++ b/typegraph/core/src/runtimes/prisma/mod.rs
@@ -1,9 +1,9 @@
 // Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
 // SPDX-License-Identifier: MPL-2.0
 
+mod constraints;
 pub mod context;
 pub mod errors;
-mod id_fields;
 pub mod migration;
 mod model;
 pub mod relationship;

--- a/typegraph/core/src/runtimes/prisma/model.rs
+++ b/typegraph/core/src/runtimes/prisma/model.rs
@@ -18,8 +18,7 @@ pub struct Model {
     pub type_id: TypeId,
     pub type_name: String,
     pub props: IndexMap<String, Property>,
-    // TODO Vec<String>
-    pub id_field: String,
+    pub id_fields: Vec<String>,
     // property -> relationship name
     pub relationships: IndexMap<String, String>,
 }
@@ -39,21 +38,26 @@ impl TryFrom<TypeId> for Model {
             .name()?
             .ok_or_else(|| errors::unnamed_model(&type_id.repr().unwrap()))?;
 
-        let id_field = Self::find_id_field(&type_name, &props)?;
+        let config = RuntimeConfig::new(typ.base().runtime_config.as_ref());
+
+        let id_fields = Self::find_id_fields(&type_name, &props, config)?;
 
         Ok(Self {
             type_id,
             type_name,
             props,
-            id_field,
+            id_fields,
             relationships: Default::default(), // populated later
         })
     }
 }
 
 impl Model {
-    fn find_id_field(type_name: &str, props: &IndexMap<String, Property>) -> Result<String> {
-        let id_fields = props
+    fn find_as_id_field(
+        type_name: &str,
+        props: &IndexMap<String, Property>,
+    ) -> Result<Option<String>> {
+        let as_id_fields = props
             .iter()
             .filter_map(|(k, p)| match p {
                 Property::Scalar(prop) => match prop.quantifier {
@@ -71,10 +75,114 @@ impl Model {
             })
             .collect::<Vec<_>>();
 
-        match id_fields.len() {
-            0 => Err(errors::id_field_not_found(type_name)),
-            1 => Ok(id_fields.into_iter().next().unwrap()),
+        match as_id_fields.len() {
+            0..=1 => Ok(as_id_fields.into_iter().next()),
             _ => Err(errors::multiple_id_fields(type_name)),
+        }
+    }
+
+    fn find_id_part_fields(
+        type_name: &str,
+        props: &IndexMap<String, Property>,
+    ) -> Result<Option<Vec<String>>> {
+        let id_part_fields = props
+            .iter()
+            .filter_map(|(k, p)| match p {
+                Property::Scalar(prop) => match prop.quantifier {
+                    Cardinality::One => {
+                        let typedef = prop.type_id.as_type_def().unwrap().unwrap();
+                        let runtime_config =
+                            RuntimeConfig::new(typedef.base().runtime_config.as_ref());
+                        let id_part = runtime_config
+                            .get("id_part")
+                            .ok()
+                            .flatten()
+                            .unwrap_or(false);
+                        id_part.then(|| k.clone())
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        match id_part_fields.len() {
+            0 => Ok(None),
+            1 => Err(
+                format!("expected more than one id_part fields on the model {type_name}").into(),
+            ),
+            _ => Ok(Some(id_part_fields)),
+        }
+    }
+
+    fn find_struct_level_ids(
+        type_name: &str,
+        config: RuntimeConfig<'_>,
+        props: &IndexMap<String, Property>,
+    ) -> Result<Option<Vec<String>>> {
+        let id_config: Option<Vec<String>> = config.get("id").ok().flatten();
+
+        let Some(id_config) = id_config else {
+            return Ok(None);
+        };
+
+        if id_config.is_empty() {
+            return Err("id config must not be empty".into());
+        }
+
+        for id_field in &id_config {
+            let prop = props
+                .get(id_field)
+                .ok_or_else(|| format!("id field {} not found", id_field))?;
+            match prop {
+                Property::Scalar(prop) => match prop.quantifier {
+                    Cardinality::One => continue,
+                    Cardinality::Optional => {
+                        return Err(format!(
+                            "id field {} must not be optional in model {type_name}",
+                            id_field
+                        )
+                        .into())
+                    }
+                    Cardinality::Many => {
+                        return Err(format!(
+                            "id field {} must not be a list in model {type_name}",
+                            id_field
+                        )
+                        .into())
+                    }
+                },
+                _ => {
+                    // TODO
+                    return Err(format!(
+                        "id field {} must be a scalar in model {type_name}",
+                        id_field
+                    )
+                    .into());
+                }
+            }
+        }
+
+        Ok(Some(id_config))
+    }
+
+    fn find_id_fields(
+        type_name: &str,
+        props: &IndexMap<String, Property>,
+        config: RuntimeConfig<'_>,
+    ) -> Result<Vec<String>> {
+        let as_id_field = Self::find_as_id_field(type_name, props)?;
+        let id_part_fields = Self::find_id_part_fields(type_name, props)?;
+        let struct_id_fields = Self::find_struct_level_ids(type_name, config, props)?;
+
+        match (as_id_field, id_part_fields, struct_id_fields) {
+            (None, None, None) => Err(errors::id_field_not_found(type_name)),
+            (Some(as_id_field), None, None) => Ok(vec![as_id_field]),
+            (None, Some(id_part_fields), None) => Ok(id_part_fields),
+            (None, None, Some(struct_id_fields)) => Ok(struct_id_fields),
+            (_, _, _) => Err("id_part, as_id and struct-level ids are mutually exclusive"
+                .to_string()
+                .into()),
         }
     }
 

--- a/typegraph/core/src/runtimes/prisma/model.rs
+++ b/typegraph/core/src/runtimes/prisma/model.rs
@@ -13,7 +13,7 @@ use crate::types::{TypeDef, TypeDefExt};
 use crate::validation::types::validate_value;
 use crate::{runtimes::prisma::relationship::Cardinality, types::TypeId};
 
-use super::id_fields::find_id_fields;
+use super::constraints::{find_id_fields, get_struct_level_unique_constraints};
 
 #[derive(Debug)]
 pub struct Model {
@@ -21,6 +21,7 @@ pub struct Model {
     pub type_name: String,
     pub props: IndexMap<String, Property>,
     pub id_fields: Vec<String>,
+    pub unique_constraints: Vec<Vec<String>>,
     // property -> relationship name
     pub relationships: IndexMap<String, String>,
 }
@@ -42,13 +43,15 @@ impl TryFrom<TypeId> for Model {
 
         let config = RuntimeConfig::new(typ.base().runtime_config.as_ref());
 
-        let id_fields = find_id_fields(&type_name, &props, config)?;
+        let id_fields = find_id_fields(&type_name, &props, &config)?;
+        let unique_constraints = get_struct_level_unique_constraints(&type_name, &config)?;
 
         Ok(Self {
             type_id,
             type_name,
             props,
             id_fields,
+            unique_constraints,
             relationships: Default::default(), // populated later
         })
     }

--- a/typegraph/core/src/runtimes/prisma/model.rs
+++ b/typegraph/core/src/runtimes/prisma/model.rs
@@ -13,6 +13,8 @@ use crate::types::{TypeDef, TypeDefExt};
 use crate::validation::types::validate_value;
 use crate::{runtimes::prisma::relationship::Cardinality, types::TypeId};
 
+use super::id_fields::find_id_fields;
+
 #[derive(Debug)]
 pub struct Model {
     pub type_id: TypeId,
@@ -40,7 +42,7 @@ impl TryFrom<TypeId> for Model {
 
         let config = RuntimeConfig::new(typ.base().runtime_config.as_ref());
 
-        let id_fields = Self::find_id_fields(&type_name, &props, config)?;
+        let id_fields = find_id_fields(&type_name, &props, config)?;
 
         Ok(Self {
             type_id,
@@ -53,139 +55,6 @@ impl TryFrom<TypeId> for Model {
 }
 
 impl Model {
-    fn find_as_id_field(
-        type_name: &str,
-        props: &IndexMap<String, Property>,
-    ) -> Result<Option<String>> {
-        let as_id_fields = props
-            .iter()
-            .filter_map(|(k, p)| match p {
-                Property::Scalar(prop) => match prop.quantifier {
-                    Cardinality::One => prop
-                        .type_id
-                        .as_type_def()
-                        .unwrap()
-                        .unwrap()
-                        .base()
-                        .as_id
-                        .then(|| k.clone()),
-                    _ => None,
-                },
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-
-        match as_id_fields.len() {
-            0..=1 => Ok(as_id_fields.into_iter().next()),
-            _ => Err(errors::multiple_id_fields(type_name)),
-        }
-    }
-
-    fn find_id_part_fields(
-        type_name: &str,
-        props: &IndexMap<String, Property>,
-    ) -> Result<Option<Vec<String>>> {
-        let id_part_fields = props
-            .iter()
-            .filter_map(|(k, p)| match p {
-                Property::Scalar(prop) => match prop.quantifier {
-                    Cardinality::One => {
-                        let typedef = prop.type_id.as_type_def().unwrap().unwrap();
-                        let runtime_config =
-                            RuntimeConfig::new(typedef.base().runtime_config.as_ref());
-                        let id_part = runtime_config
-                            .get("id_part")
-                            .ok()
-                            .flatten()
-                            .unwrap_or(false);
-                        id_part.then(|| k.clone())
-                    }
-                    _ => None,
-                },
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-
-        match id_part_fields.len() {
-            0 => Ok(None),
-            1 => Err(
-                format!("expected more than one id_part fields on the model {type_name}").into(),
-            ),
-            _ => Ok(Some(id_part_fields)),
-        }
-    }
-
-    fn find_struct_level_ids(
-        type_name: &str,
-        config: RuntimeConfig<'_>,
-        props: &IndexMap<String, Property>,
-    ) -> Result<Option<Vec<String>>> {
-        let id_config: Option<Vec<String>> = config.get("id").ok().flatten();
-
-        let Some(id_config) = id_config else {
-            return Ok(None);
-        };
-
-        if id_config.is_empty() {
-            return Err("id config must not be empty".into());
-        }
-
-        for id_field in &id_config {
-            let prop = props
-                .get(id_field)
-                .ok_or_else(|| format!("id field {} not found", id_field))?;
-            match prop {
-                Property::Scalar(prop) => match prop.quantifier {
-                    Cardinality::One => continue,
-                    Cardinality::Optional => {
-                        return Err(format!(
-                            "id field {} must not be optional in model {type_name}",
-                            id_field
-                        )
-                        .into())
-                    }
-                    Cardinality::Many => {
-                        return Err(format!(
-                            "id field {} must not be a list in model {type_name}",
-                            id_field
-                        )
-                        .into())
-                    }
-                },
-                _ => {
-                    // TODO
-                    return Err(format!(
-                        "id field {} must be a scalar in model {type_name}",
-                        id_field
-                    )
-                    .into());
-                }
-            }
-        }
-
-        Ok(Some(id_config))
-    }
-
-    fn find_id_fields(
-        type_name: &str,
-        props: &IndexMap<String, Property>,
-        config: RuntimeConfig<'_>,
-    ) -> Result<Vec<String>> {
-        let as_id_field = Self::find_as_id_field(type_name, props)?;
-        let id_part_fields = Self::find_id_part_fields(type_name, props)?;
-        let struct_id_fields = Self::find_struct_level_ids(type_name, config, props)?;
-
-        match (as_id_field, id_part_fields, struct_id_fields) {
-            (None, None, None) => Err(errors::id_field_not_found(type_name)),
-            (Some(as_id_field), None, None) => Ok(vec![as_id_field]),
-            (None, Some(id_part_fields), None) => Ok(id_part_fields),
-            (None, None, Some(struct_id_fields)) => Ok(struct_id_fields),
-            (_, _, _) => Err("id_part, as_id and struct-level ids are mutually exclusive"
-                .to_string()
-                .into()),
-        }
-    }
-
     pub fn iter_props(&self) -> impl Iterator<Item = (&String, &Property)> {
         self.props.iter()
     }

--- a/typegraph/core/src/runtimes/prisma/type_generation/query_unique_where_expr.rs
+++ b/typegraph/core/src/runtimes/prisma/type_generation/query_unique_where_expr.rs
@@ -28,7 +28,7 @@ impl TypeGen for QueryUniqueWhereExpr {
         for (k, prop) in model.iter_props() {
             match prop {
                 Property::Scalar(prop) => {
-                    if &model.id_field == k || prop.unique {
+                    if model.id_fields.contains(k) || prop.unique {
                         builder.propx(k, t::optional(prop.type_id))?;
                     }
                 }

--- a/website/static/specs/0.0.3.json
+++ b/website/static/specs/0.0.3.json
@@ -1713,7 +1713,8 @@
         "idFields",
         "props",
         "typeIdx",
-        "typeName"
+        "typeName",
+        "uniqueConstraints"
       ],
       "properties": {
         "typeIdx": {
@@ -1734,6 +1735,15 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "uniqueConstraints": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }


### PR DESCRIPTION
Adds support for more advanced id fields and unique constraints:
- Multi-field id
- Id on struct (foreign key)
- Multi-field unique constraints
- Unique constraint on struct (foreign key)

#### Motivation and context

Support these kind of construct:

```python
user = t.struct(
  {
    "authProvider": t.string().from_context("provider"),
    "profileId": t.string().from_context("profile.id"),
    # ...
  },
  config={"id": ["authProvider", "profileId"]},
).rename("User")

project = t.struct(
  {
    "id": t.uuid(as_id=True, config=["auto"]),
    "owner": g.ref("Account"),
    "name": t.string(min=3, pattern="^[A-Za-z_-]$"),
  },
  config={"unique": [["owner", "name"]]}
).rename("Project")
```


#### Migration notes

_No migration needed._

### Checklist

- [x] The change come with new or modified tests
- [x] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
