### PR TITLE
fix(cli, typegate): explicitly import DenoRuntime.import modules from path

### DIFF
--- a/typegate/src/main.ts
+++ b/typegate/src/main.ts
@@ -89,4 +89,5 @@ try {
   await server.finished;
 } catch (err) {
   logger.error(err);
+  throw err;
 }

--- a/typegate/src/runtimes/deno/deno.ts
+++ b/typegate/src/runtimes/deno/deno.ts
@@ -69,6 +69,7 @@ export class DenoRuntime extends Runtime {
       "deno",
       name.replaceAll(" ", "_"), // TODO: improve sanitization
     );
+    logger.debug(Deno.inspect({ basePath, tmpDir: config.tmp_dir }));
 
     try {
       // clean up old files

--- a/typegate/src/runtimes/deno/deno.ts
+++ b/typegate/src/runtimes/deno/deno.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 
 import { toFileUrl } from "std/path/mod.ts";
-import * as url from "std/url/mod.ts";
 import { ComputeStage } from "../../engine/query_engine.ts";
 import { TypeGraphDS, TypeMaterializer } from "../../typegraph/mod.ts";
 import { Runtime } from "../Runtime.ts";
@@ -104,10 +103,10 @@ export class DenoRuntime extends Runtime {
         );
 
         logger.info(`uncompressed ${entries.join(", ")} at ${outDir}`);
-        const modulePath = url.join(
-          toFileUrl(outDir),
-          `${repr.entryPoint}?hash=${repr.hashes.content}`,
-        ).toString();
+        const modulePath = toFileUrl(
+          path.resolve(outDir, repr.entryPoint),
+        ).toString() + `?hash=${repr.hashes.content}`;
+
         logger.debug(`registering op ${registryCount} from ${modulePath}`);
         // Note:
         // Worker destruction seems to have no effect on the import cache? (deinit() => stop(worker))

--- a/typegate/src/runtimes/deno/deno.ts
+++ b/typegate/src/runtimes/deno/deno.ts
@@ -1,6 +1,7 @@
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
+import { toFileUrl } from "std/path/mod.ts";
 import { ComputeStage } from "../../engine/query_engine.ts";
 import { TypeGraphDS, TypeMaterializer } from "../../typegraph/mod.ts";
 import { Runtime } from "../Runtime.ts";
@@ -11,7 +12,7 @@ import { InternalAuth } from "../../services/auth/protocols/internal.ts";
 import { DenoMessenger } from "./deno_messenger.ts";
 import { Task } from "./shared_types.ts";
 import { structureRepr, uncompress } from "../../utils.ts";
-import { path } from "compress/deps.ts";
+import { path, url } from "compress/deps.ts";
 import config from "../../config.ts";
 import { getLogger } from "../../log.ts";
 
@@ -107,8 +108,8 @@ export class DenoRuntime extends Runtime {
         // hence the use of contentHash
         ops.set(registryCount, {
           type: "register_import_func",
-          modulePath: path.join(
-            outDir,
+          modulePath: url.join(
+            toFileUrl(outDir),
             `${repr.entryPoint}?hash=${repr.hashes.content}`,
           ),
           op: registryCount,

--- a/typegate/src/runtimes/deno/deno.ts
+++ b/typegate/src/runtimes/deno/deno.ts
@@ -103,17 +103,15 @@ export class DenoRuntime extends Runtime {
         );
 
         logger.info(`uncompressed ${entries.join(", ")} at ${outDir}`);
-        const modulePath = toFileUrl(
-          path.resolve(outDir, repr.entryPoint),
-        ).toString() + `?hash=${repr.hashes.content}`;
 
-        logger.debug(`registering op ${registryCount} from ${modulePath}`);
         // Note:
         // Worker destruction seems to have no effect on the import cache? (deinit() => stop(worker))
         // hence the use of contentHash
         ops.set(registryCount, {
           type: "register_import_func",
-          modulePath,
+          modulePath: toFileUrl(
+            path.resolve(outDir, repr.entryPoint),
+          ).toString() + `?hash=${repr.hashes.content}`,
           op: registryCount,
           verbose: config.debug,
         });

--- a/typegate/src/runtimes/deno/deno.ts
+++ b/typegate/src/runtimes/deno/deno.ts
@@ -69,7 +69,6 @@ export class DenoRuntime extends Runtime {
       "deno",
       name.replaceAll(" ", "_"), // TODO: improve sanitization
     );
-    logger.debug(Deno.inspect({ basePath, tmpDir: config.tmp_dir }));
 
     try {
       // clean up old files

--- a/typegate/src/runtimes/deno/deno.ts
+++ b/typegate/src/runtimes/deno/deno.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 
 import { toFileUrl } from "std/path/mod.ts";
+import * as url from "std/url/mod.ts";
 import { ComputeStage } from "../../engine/query_engine.ts";
 import { TypeGraphDS, TypeMaterializer } from "../../typegraph/mod.ts";
 import { Runtime } from "../Runtime.ts";
@@ -12,7 +13,7 @@ import { InternalAuth } from "../../services/auth/protocols/internal.ts";
 import { DenoMessenger } from "./deno_messenger.ts";
 import { Task } from "./shared_types.ts";
 import { structureRepr, uncompress } from "../../utils.ts";
-import { path, url } from "compress/deps.ts";
+import { path } from "compress/deps.ts";
 import config from "../../config.ts";
 import { getLogger } from "../../log.ts";
 

--- a/typegate/src/runtimes/deno/deno.ts
+++ b/typegate/src/runtimes/deno/deno.ts
@@ -89,7 +89,7 @@ export class DenoRuntime extends Runtime {
           type: "register_func",
           fnCode: code,
           op: registryCount,
-          verbose: false,
+          verbose: config.debug,
         });
         registry.set(code, registryCount);
         registryCount += 1;
@@ -104,17 +104,19 @@ export class DenoRuntime extends Runtime {
         );
 
         logger.info(`uncompressed ${entries.join(", ")} at ${outDir}`);
+        const modulePath = url.join(
+          toFileUrl(outDir),
+          `${repr.entryPoint}?hash=${repr.hashes.content}`,
+        ).toString();
+        logger.debug(`registering op ${registryCount} from ${modulePath}`);
         // Note:
         // Worker destruction seems to have no effect on the import cache? (deinit() => stop(worker))
         // hence the use of contentHash
         ops.set(registryCount, {
           type: "register_import_func",
-          modulePath: url.join(
-            toFileUrl(outDir),
-            `${repr.entryPoint}?hash=${repr.hashes.content}`,
-          ),
+          modulePath,
           op: registryCount,
-          verbose: false,
+          verbose: config.debug,
         });
         registry.set(code, registryCount);
         registryCount += 1;

--- a/typegate/src/runtimes/deno/worker.ts
+++ b/typegate/src/runtimes/deno/worker.ts
@@ -1,6 +1,8 @@
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
+import { toFileUrl } from "std/path/mod.ts";
+
 import { getLogger } from "../../log.ts";
 import { Answer, Message } from "../patterns/messenger/types.ts";
 
@@ -92,9 +94,10 @@ async function func(op: number, task: FuncTask) {
 async function register_import_func(_: null, task: RegisterImportFuncTask) {
   const { modulePath, verbose, op } = task;
   verbose && logger.info(`register import func "${op}"`);
+  const url = toFileUrl(modulePath);
   registry.set(
     op,
-    await import(modulePath),
+    await import(url),
   );
 }
 

--- a/typegate/src/runtimes/deno/worker.ts
+++ b/typegate/src/runtimes/deno/worker.ts
@@ -1,8 +1,6 @@
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
-import { toFileUrl } from "std/path/mod.ts";
-
 import { getLogger } from "../../log.ts";
 import { Answer, Message } from "../patterns/messenger/types.ts";
 
@@ -94,10 +92,9 @@ async function func(op: number, task: FuncTask) {
 async function register_import_func(_: null, task: RegisterImportFuncTask) {
   const { modulePath, verbose, op } = task;
   verbose && logger.info(`register import func "${op}"`);
-  const url = toFileUrl(modulePath);
   registry.set(
     op,
-    await import(url),
+    await import(modulePath),
   );
 }
 

--- a/typegate/src/runtimes/deno/worker.ts
+++ b/typegate/src/runtimes/deno/worker.ts
@@ -91,7 +91,8 @@ async function func(op: number, task: FuncTask) {
 
 async function register_import_func(_: null, task: RegisterImportFuncTask) {
   const { modulePath, verbose, op } = task;
-  verbose && logger.info(`register import func "${op}"`);
+  verbose &&
+    logger.info(`register import func "${op}" from "${modulePath.toString()}`);
   registry.set(
     op,
     await import(modulePath),


### PR DESCRIPTION
When using the dynamic `import` function, if you provide it a raw path like `/foo/bar/baz` and deno detects the current module's loaded from a remote host, it'll convert it to a http url. Reasonable behavior but it turned out to be the cause of #560.

This pr fixes this issue along with:
- Puts contents of `main.ts` in a try/catch block for better error logging.
- Fixes minor permission bugs with the bundled runtime.

#### Motivation and context

#560 

#### Migration notes

_No changes required_

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
