### PR TITLE
fix(ci): minor typo in `release.yml/docker`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
         with:
           path: ./digests
           pattern: digests-*
-          merge-multiple: digests-*
+          merge-multiple: true
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Small typo blocking the job that pushes the images to ghcr.io.

#### Motivation and context

[Broken run.](https://github.com/metatypedev/metatype/actions/runs/7748712325/job/21132659221)

#### Migration notes

_No changes required._

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
