### PR TITLE
fix: hotfix typo in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,6 @@ jobs:
         with:
           file: dev/Dockerfile
           platforms: ${{ matrix.platform }}
-          target: prd
           cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - run: |


### PR DESCRIPTION
Yes, another one lol. This removes the `target` param from the release builder which will default to the last stage of the Dockerfile, the `epoint` stage.  I elected to remove the parameter rather than replacing the value in order to remove one more place future changes will have to consider. (convention better than configuration the saying goes (i think)).

#### Motivation and context

The `typegate` images currently have the wrong target and thus the wrong `entrypoint` command.

#### Migration notes

_No changes required_

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
