### PR TITLE
fix: Show error message for unregistered type name

### DIFF
--- a/typegate/tests/regression/invalid_ref_error_message/invalid_ref.py
+++ b/typegate/tests/regression/invalid_ref_error_message/invalid_ref.py
@@ -1,0 +1,12 @@
+from typegraph import typegraph, Graph, Policy, t
+from typegraph.runtimes import DenoRuntime
+
+
+@typegraph()
+def invalid_ref(g: Graph):
+    public = Policy.public()
+    deno = DenoRuntime()
+
+    user = t.struct({"id": t.uuid(), "posts": t.list(g.ref("Post"))})
+
+    g.expose(public, user=deno.identity(user))

--- a/typegate/tests/regression/invalid_ref_error_message/invalid_ref_test.ts
+++ b/typegate/tests/regression/invalid_ref_error_message/invalid_ref_test.ts
@@ -1,0 +1,15 @@
+// Copyright Metatype OÜ, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+import { Meta } from "test-utils/mod.ts";
+import { assertRejects } from "std/assert/mod.ts";
+
+Meta.test("invalid ref", async (t) => {
+  await assertRejects(
+    () =>
+      t.engine(
+        "regression/invalid_ref_error_message/invalid_ref.py",
+      ),
+    "type name 'Post' has not been registered",
+  );
+});

--- a/typegraph/python/typegraph/graph/typegraph.py
+++ b/typegraph/python/typegraph/graph/typegraph.py
@@ -79,11 +79,14 @@ class Typegraph:
         default_policy: Optional[PolicySpec] = None,
         **kwargs: ExposeItem,
     ):
-        core.expose(
+        res = core.expose(
             store,
             [(k, v.id) for k, v in kwargs.items()],
             default_policy=get_policy_chain(default_policy) if default_policy else None,
         )
+
+        if isinstance(res, Err):
+            raise Exception(res.value)
 
 
 @dataclass


### PR DESCRIPTION
Check and throw the error for the `expose` function when called from the Python SDK.

#### Motivation and context

We got a finalization failure when there are some unregistered type referenced with `g.ref`.

#### Migration notes

_No changes needed._

### Checklist

- [x] The change come with new or modified tests
- [x] Hard-to-understand functions have explanatory comments
- [x] End-user documentation is updated to reflect the change
