### PR TITLE
fix(gate): `RandomRuntime` does not consider `enum`, `either`, `union` variants

### DIFF
--- a/typegate/src/runtimes/random.ts
+++ b/typegate/src/runtimes/random.ts
@@ -176,9 +176,15 @@ export default function randomizeRecursively(
         chance,
         tgTypes,
       );
-      console.log(
-        "**********Either",
-        result,
+      return result;
+    }
+    case "union": {
+      const result = randomizeRecursively(
+        tgTypes[
+          typ.anyOf[chance.integer({ min: 0, max: typ.anyOf.length - 1 })]
+        ],
+        chance,
+        tgTypes,
       );
       return result;
     }

--- a/typegate/src/runtimes/random.ts
+++ b/typegate/src/runtimes/random.ts
@@ -151,7 +151,7 @@ export default function randomizeRecursively(
         return generateEAN(chance);
       }
       if (typ.enum) {
-        // TODO: use sth simpler than regex, may be .map(x => string(x))
+        // remove extra " from the string
         return chance.pickone(typ.enum).replace(/^"(.*)"$/, "$1");
       }
       return chance.string();

--- a/typegate/src/runtimes/random.ts
+++ b/typegate/src/runtimes/random.ts
@@ -152,7 +152,7 @@ export default function randomizeRecursively(
       }
       if (typ.enum) {
         // remove extra " from the string
-        return chance.pickone(typ.enum).replace(/^"(.*)"$/, "$1");
+        return JSON.parse(chance.pickone(typ.enum));
       }
       return chance.string();
     case "boolean":

--- a/typegate/tests/random/injection/random_injection.py
+++ b/typegate/tests/random/injection/random_injection.py
@@ -34,18 +34,45 @@ def random_injection(g: Graph):
         }
     )
 
+    # test int, str, float enum
     test_enum_str = t.struct(
-        {"educationLevel": t.enum(["primary", "secondary", "tertiary"]).from_random()}
+        {
+            "educationLevel": t.enum(
+                ["primary", "secondary", "tertiary"]
+            ).from_random(),
+        }
     )
 
-    test_enum_int = t.struct({"bits": t.integer(enum=[0, 1]).from_random()})
+    test_enum_int = t.struct(
+        {
+            "bits": t.integer(enum=[0, 1]).from_random(),
+        }
+    )
 
-    test_enum_float = t.struct({"cents": t.float(enum=[0.25, 0.5, 1.0]).from_random()})
+    test_enum_float = t.struct(
+        {
+            "cents": t.float(enum=[0.25, 0.5, 1.0]).from_random(),
+        }
+    )
 
+    # test either
     rubix_cube = t.struct({"name": t.string(), "size": t.integer()}, name="Rubix")
     toygun = t.struct({"color": t.string()}, name="Toygun")
     toy = t.either([rubix_cube, toygun], name="Toy").from_random()
-    toy_struct = t.struct({"toy": toy})
+    toy_struct = t.struct(
+        {
+            "toy": toy,
+        }
+    )
+
+    # test union
+    rgb = t.struct({"R": t.float(), "G": t.float(), "B": t.float()}, name="Rgb")
+    vec = t.struct({"x": t.float(), "y": t.float(), "z": t.float()}, name="Vec")
+    union_struct = t.struct(
+        {
+            "field": t.union([rgb, vec], name="UnionStruct").from_random(),
+        }
+    )
 
     random_list = t.struct(
         {
@@ -62,4 +89,5 @@ def random_injection(g: Graph):
         testEnumInt=deno.identity(test_enum_int),
         testEnumFloat=deno.identity(test_enum_float),
         testEither=deno.identity(toy_struct),
+        testUnion=deno.identity(union_struct),
     )

--- a/typegate/tests/random/injection/random_injection.py
+++ b/typegate/tests/random/injection/random_injection.py
@@ -34,6 +34,19 @@ def random_injection(g: Graph):
         }
     )
 
+    test_enum_str = t.struct(
+        {"educationLevel": t.enum(["primary", "secondary", "tertiary"]).from_random()}
+    )
+
+    test_enum_int = t.struct({"bits": t.integer(enum=[0, 1]).from_random()})
+
+    test_enum_float = t.struct({"cents": t.float(enum=[0.25, 0.5, 1.0]).from_random()})
+
+    rubix_cube = t.struct({"name": t.string(), "size": t.integer()}, name="Rubix")
+    toygun = t.struct({"color": t.string()}, name="Toygun")
+    toy = t.either([rubix_cube, toygun], name="Toy").from_random()
+    toy_struct = t.struct({"toy": toy})
+
     random_list = t.struct(
         {
             "names": t.list(t.string(config={"gen": "name"})).from_random(),
@@ -45,4 +58,8 @@ def random_injection(g: Graph):
         pub,
         randomUser=deno.identity(user),
         randomList=deno.identity(random_list),
+        testEnumStr=deno.identity(test_enum_str),
+        testEnumInt=deno.identity(test_enum_int),
+        testEnumFloat=deno.identity(test_enum_float),
+        testEither=deno.identity(toy_struct),
     )

--- a/typegate/tests/random/injection/random_injection_test.ts
+++ b/typegate/tests/random/injection/random_injection_test.ts
@@ -75,6 +75,52 @@ Meta.test("Python: Random Injection", async (metaTest) => {
       },
     }).on(engine);
   });
+
+  await metaTest.should(
+    "generate random values for on enums, either and union variants",
+    async () => {
+      await gql`
+      query {
+        testEnumStr {
+          educationLevel
+        },
+        testEnumInt {
+          bits
+        },
+        testEnumFloat {
+          cents
+        },
+        testEither {
+          toy {
+            ... on Toygun {
+              color
+            }
+            ... on Rubix {
+              name,
+              size
+            }
+          }
+        }
+      }
+    `.expectData({
+        testEnumStr: {
+          educationLevel: "secondary",
+        },
+        testEnumInt: {
+          bits: 0,
+        },
+        testEnumFloat: {
+          cents: 0.5,
+        },
+        testEither: {
+          toy: {
+            name: "1*ajw]krgDnCzXD*N!Fx",
+            size: 3336617896968192,
+          },
+        },
+      }).on(engine);
+    },
+  );
 });
 
 Meta.test("Deno: Random Injection", async (metaTest) => {

--- a/typegate/tests/random/injection/random_injection_test.ts
+++ b/typegate/tests/random/injection/random_injection_test.ts
@@ -77,7 +77,7 @@ Meta.test("Python: Random Injection", async (metaTest) => {
   });
 
   await metaTest.should(
-    "generate random values for on enums, either and union variants",
+    "generate random values for enums, either and union variants",
     async () => {
       await gql`
       query {
@@ -100,6 +100,20 @@ Meta.test("Python: Random Injection", async (metaTest) => {
               size
             }
           }
+        },
+        testUnion {
+          field {
+            ... on Rgb {
+              R
+              G
+              B
+            }
+            ... on Vec {
+              x
+              y
+              z
+            }
+          }
         }
       }
     `.expectData({
@@ -116,6 +130,13 @@ Meta.test("Python: Random Injection", async (metaTest) => {
           toy: {
             name: "1*ajw]krgDnCzXD*N!Fx",
             size: 3336617896968192,
+          },
+        },
+        testUnion: {
+          field: {
+            B: 779226068287.488,
+            G: 396901315143.2704,
+            R: 895648526657.1263,
           },
         },
       }).on(engine);

--- a/typegate/tests/random/random.ts
+++ b/typegate/tests/random/random.ts
@@ -8,12 +8,37 @@ typegraph("random", (g: any) => {
   const random = new RandomRuntime({ seed: 1, reset: "" });
   const pub = Policy.public();
 
+  // test for enum, union, either
+  const rgb = t.struct({
+    "R": t.float(),
+    "G": t.float(),
+    "B": t.float(),
+  }, { name: "Rgb" });
+  const vec = t.struct({ "x": t.float(), "y": t.float(), "z": t.float() }, {
+    name: "Vec",
+  });
+
+  const rubix_cube = t.struct({ "name": t.string(), "size": t.integer() }, {
+    name: "Rubix",
+  });
+  const toygun = t.struct({ "color": t.string() }, { name: "Toygun" });
+
+  const testStruct = t.struct({
+    field: t.union([rgb, vec]),
+    toy: t.either([rubix_cube, toygun]),
+    educationLevel: t.enum_(["primary", "secondary", "tertiary"]),
+    cents: t.float({ enumeration: [0.25, 0.5, 1.0] }),
+  });
+
   g.expose({
     test1: random.gen(
       t.struct({
         email: t.email(),
         country: t.string({}, { config: { gen: "country", full: true } }),
       }),
+    ).withPolicy(pub),
+    test2: random.gen(
+      testStruct,
     ).withPolicy(pub),
   });
 });

--- a/typegate/tests/random/random_test.ts
+++ b/typegate/tests/random/random_test.ts
@@ -19,10 +19,10 @@ Meta.test("Python: Random", async (t) => {
     `
       .expectData({
         randomRec: {
-          uuid: "1069ace0-cdb1-5c1f-8193-81f53d29da35",
-          int: 7457276839329792,
-          str: "HPFk*o570)7",
-          email: "vi@itabefir.bb",
+          email: "vu@jel.ml",
+          int: 7360602246742016,
+          str: "v%vijM",
+          uuid: "415013d6-efc5-5781-aa74-056ee27dbb22",
         },
       })
       .on(e);
@@ -46,14 +46,14 @@ Meta.test("Python: Random", async (t) => {
     `
       .expectData({
         randomUser: {
-          id: "415013d6-efc5-5781-aa74-056ee27dbb22",
-          name: "Gertrude Robertson",
-          age: 61,
+          age: 35,
+          id: "190a524b-b70b-52f4-911d-7974ea74cf43",
+          name: "Chase Dennis",
           address: {
-            street: "579 Dico Turnpike",
-            city: "Igpisi",
-            postcode: "NR1 5GS",
-            country: "Croatia",
+            city: "Peehhiz",
+            country: "Mexico",
+            postcode: "TA2G 2CP",
+            street: "103 Pafma Circle",
           },
         },
       })
@@ -73,47 +73,54 @@ Meta.test("Python: Random", async (t) => {
           randomList: {
             array_of_array_of_names: [
               [
-                "Olivia Smith",
-                "Sean Atkins",
-                "Arthur Parker",
-                "Jack Chavez",
-                "Hunter Franklin",
-                "Betty Gill",
-                "Louis Reeves",
-                "Rosa Hansen",
-                "Blanche White",
-                "Essie Marsh",
+                "Ethel Casey",
+                "Della Garner",
+                "Ronald Wade",
+                "Clayton Tate",
+                "Martin Neal",
+                "Charlie Soto",
               ],
               [
-                "Caleb Meyer",
-                "Glen Hayes",
-                "Bernice Delgado",
-                "Bernice Rose",
-                "Ronnie Vargas",
+                "Jessie Fleming",
               ],
               [
-                "Marguerite Tyler",
-                "Erik Robinson",
-                "Gregory King",
-                "Essie Collins",
-                "Henrietta Cummings",
-                "Esther Wade",
-                "Shane Holmes",
-                "Jacob Warner",
-                "Gussie Castillo",
+                "Bertha Watts",
+                "Cecelia Neal",
+                "Gabriel Ramirez",
+                "Jean Carpenter",
+                "Alfred Jenkins",
+                "Cecilia Bradley",
+                "Lee Potter",
+                "Eunice Cox",
               ],
-              ["Julian Curry"],
               [
-                "Lelia Daniels",
-                "Gabriel Webster",
-                "Ronald Baker",
-                "Dale Owen",
-                "Harry Poole",
-                "Frank Ward",
-                "Margaret Perez",
-                "Verna Wallace",
-                "Flora Daniels",
-                "Derek Allen",
+                "Mable Leonard",
+                "Belle Olson",
+                "Susie Hart",
+                "Nelle Banks",
+                "Loretta Davis",
+                "Delia Love",
+                "Jeffrey Adkins",
+                "Laura Harvey",
+                "Jeffery Figueroa",
+              ],
+              [
+                "Arthur Patton",
+                "Minerva Miles",
+                "James Maldonado",
+                "Myrtle Gardner",
+                "Evelyn Brown",
+              ],
+              [
+                "Belle Dean",
+                "Lilly Steele",
+                "Michael Mason",
+                "Gussie Burgess",
+                "Rosalie Adams",
+                "Cody Gray",
+                "Olivia Alexander",
+                "Lola Scott",
+                "Miguel Pearson",
               ],
             ],
           },
@@ -137,10 +144,55 @@ Meta.test("Deno: Random", async (t) => {
     `
       .expectData({
         test1: {
-          email: "wubju@de.cg",
-          country: "Guyana",
+          country: "Turkey",
+          email: "mummer@nubi.no",
         },
       })
       .on(e);
+  });
+
+  await t.should("work on enum, union, and either types", async () => {
+    await gql`
+      query {
+        test2 {
+          field {
+            ... on Rgb {
+              R
+              G
+              B
+            }
+            ... on Vec {
+              x
+              y
+              z
+            }
+          }
+          toy {
+            ... on Rubix {
+              name
+              size
+            }
+            ... on Toygun {
+              color
+            }
+          }
+          educationLevel
+          cents
+        }
+      }
+    `.expectData({
+      test2: {
+        field: {
+          x: -158908830187.52,
+          y: 59745273852.7232,
+          z: -544843873281.6384,
+        },
+        toy: {
+          color: "]W3wuH6qhfHI^h",
+        },
+        cents: 1,
+        educationLevel: "primary",
+      },
+    }).on(e);
   });
 });

--- a/typegate/tests/runtimes/prisma/mixed_runtime_test.ts
+++ b/typegate/tests/runtimes/prisma/mixed_runtime_test.ts
@@ -135,7 +135,7 @@ Meta.test("prisma mixed runtime", async (t) => {
             id: "1",
             title: "Test",
           },
-          user: { name: "Landon Glover", age: 62 },
+          user: { age: 65, name: "Nicholas Mills" },
         },
       })
         .on(e);

--- a/typegate/tests/typecheck/type_alias_test.ts
+++ b/typegate/tests/typecheck/type_alias_test.ts
@@ -18,9 +18,9 @@ Meta.test("Random", async (t) => {
     `
       .expectData({
         get_message: {
-          a: -1494798787674112,
-          title: "1*ajw]krgDnCzXD*N!Fx",
-          B: 3336617896968192,
+          B: -6252260489166848,
+          a: -6940119625891840,
+          title: "(eHAQ*ECr4%5Qwa5T",
         },
       })
       .on(e);
@@ -40,9 +40,9 @@ Meta.test("Random", async (t) => {
     `
         .expectData({
           one: {
-            two: 442220385665024,
-            three: "G#qcNX^E",
-            four: -770929621729280,
+            four: 7781716965982208,
+            three: "ye12M52^m",
+            two: 2221033285222400,
           },
         })
         .on(e);
@@ -72,23 +72,18 @@ Meta.test("Random", async (t) => {
       }
     `
       .expectData({
-        some_alias: { some_id: 1057261938016256, title: "k*o570)7xgZ" },
+        some_alias: { some_id: -8923192479449088, title: "tXIHACrEbD" },
         get_message: {
-          user_id: 327007237832704,
+          user_id: 6379176739209216,
           info: [
-            { title: "%9g9cume#XhRFX(ENo", content: "V1j$ZUV3Az4tA%3F$" },
-            { title: "vxkY59Ebc3U]W3wu", content: "aXKUfi6(eHAQ*ECr4%5Q" },
-            { title: "6qhfHI^hv%vi", content: "a5TlyQNa$" },
-            { title: "MbgY^p^", content: "AI^4UIbt&9ZO]fmI" },
-            { title: "wKRdPQTk(", content: "2*oZIer" },
-            { title: "tZrhNE(ZKEOd4N", content: "L3p&d0MjmbDbhcLsh" },
-            { title: "XkM6*", content: "vNrO)!ujrugRQ)EPBb" },
-            { title: "R$%Ok", content: "7vr17TCF@33FPFkAel" },
-            { title: "k%7BDNmW&AzQ", content: "*d^h5q" },
+            { content: "c(3]DC39H[", title: "Rg!mCL36" },
+            { content: "RJXJg7]D5%]c", title: "%Oq(27tcP0jIB" },
+            { content: "5cj1TYaTNhau(5%", title: "gqLtZgHFAi8Ud7CZH42z" },
+            { content: "6L^0kflTn9UZ^P]@032", title: "!uF88WUak2fSbYeRHQi" },
           ],
         },
-        some_alias_2: { some_title: "0cPWajfv)AQupf" },
-        some_alias_3: { some_title: "l3lo*RB)d" },
+        some_alias_2: { some_title: "KB2bni&" },
+        some_alias_3: { some_title: "S#4]L*K" },
       })
       .on(e);
   });


### PR DESCRIPTION
add either, enum, struct and union type support in Random Runtime. 

#### Motivation and context

generating random values for enums, either and union types was failing. 

#### Migration notes

_No Migrations Needed

### Checklist

- [x] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
