### PR TITLE
feat(sdk, gate, cli):  upload protocol poc  uploading wasm file for `WasmEdge Runtime` for single replica mode

### DIFF
--- a/libs/common/src/typegraph/mod.rs
+++ b/libs/common/src/typegraph/mod.rs
@@ -10,6 +10,7 @@ pub mod visitor;
 
 pub use types::*;
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -99,6 +100,7 @@ pub struct TypeMeta {
     pub rate: Option<Rate>,
     pub version: String,
     pub random_seed: Option<u32>,
+    pub ref_files: HashMap<String, String>,
 }
 
 #[cfg_attr(feature = "codegen", derive(JsonSchema))]

--- a/libs/common/src/typegraph/mod.rs
+++ b/libs/common/src/typegraph/mod.rs
@@ -100,7 +100,7 @@ pub struct TypeMeta {
     pub rate: Option<Rate>,
     pub version: String,
     pub random_seed: Option<u32>,
-    pub ref_files: HashMap<String, String>,
+    pub ref_files: HashMap<String, PathBuf>,
 }
 
 #[cfg_attr(feature = "codegen", derive(JsonSchema))]

--- a/libs/common/src/typegraph/runtimes/wasmedge.rs
+++ b/libs/common/src/typegraph/runtimes/wasmedge.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct WasiMatData {
     pub wasm: String,
     pub func: String,
+    pub artifact_hash: String,
 }
 
 #[cfg_attr(feature = "codegen", derive(JsonSchema))]

--- a/typegate/engine/src/runtimes/wasmedge.rs
+++ b/typegate/engine/src/runtimes/wasmedge.rs
@@ -54,9 +54,10 @@ fn param_cast(out: &str, res: &mut Vec<Box<dyn Any + Send + Sync>>) -> Result<St
 pub fn op_wasmedge_wasi(#[serde] input: WasiInput) -> Result<String> {
     // https://github.com/second-state/wasmedge-rustsdk-examples
 
-    let bytes = general_purpose::STANDARD
-        .decode(input.wasm.as_bytes())
-        .unwrap();
+    let wasm_path = PathBuf::from(input.wasm);
+    let wasm_binary = common::archive::encode_to_base_64(&wasm_path).unwrap();
+
+    let bytes = general_purpose::STANDARD.decode(wasm_binary).unwrap();
     let module = Module::from_bytes(None, bytes).unwrap();
 
     let config = ConfigBuilder::default()

--- a/typegate/src/engine/query_engine.ts
+++ b/typegate/src/engine/query_engine.ts
@@ -114,6 +114,13 @@ export interface EndpointToSchemaMap {
   [index: string]: { fnName: string; outputSchema: unknown };
 }
 
+export interface UploadUrlMeta {
+  fileName: string;
+  fileHash: string;
+  fileSizeInBytes: number;
+  urlUsed: boolean;
+}
+
 export class QueryEngine {
   name: string;
   queryCache: QueryCache;
@@ -131,6 +138,7 @@ export class QueryEngine {
       }
     >
   >;
+  fileUploadUrlCache: Map<string, UploadUrlMeta> = new Map();
 
   get rawName(): string {
     return this.tg.rawName;

--- a/typegate/src/services/file_upload_service.ts
+++ b/typegate/src/services/file_upload_service.ts
@@ -81,6 +81,7 @@ export async function handleFileUpload(
     throw new Error("File size does not match");
   }
 
+  // adjust relative to the root path
   const fileStorageDir = `metatype_artifacts/${engine.name}/files`;
   await Deno.mkdir(fileStorageDir, { recursive: true });
   const filePath = `${fileStorageDir}/${fileName}.${fileHash}`;

--- a/typegate/src/services/file_upload_service.ts
+++ b/typegate/src/services/file_upload_service.ts
@@ -1,50 +1,94 @@
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
-function createUploadPath(origin: string, typegraphName: string) {
-  const rand_path = crypto.randomUUID();
-  return `${origin}/${typegraphName}/files/${rand_path}`;
-}
-
-export function handleUploadUrl(request: Request, typegraphName: string) {
-  const url = new URL(request.url);
-  const origin = url.origin;
-
-  const uploadUrl = createUploadPath(origin, typegraphName);
-  return new Response(uploadUrl);
-}
+import { UploadUrlMeta } from "../engine/query_engine.ts";
+import { QueryEngine } from "../engine/query_engine.ts";
 
 interface TypegraphFile {
   name: string;
   fileHash: string;
   fileSizeInBytes: number;
-  file: string;
+}
+
+function createUploadPath(origin: string, typegraphName: string) {
+  const rand_path = crypto.randomUUID();
+  return `${origin}/upload-files/${typegraphName}/files/${rand_path}`;
+}
+
+export async function handleUploadUrl(request: Request, engine: QueryEngine) {
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const { name, fileHash, fileSizeInBytes }: TypegraphFile = await request
+    .json();
+
+  const uploadUrlMeta: UploadUrlMeta = {
+    fileName: name,
+    fileHash: fileHash,
+    fileSizeInBytes: fileSizeInBytes,
+    urlUsed: false,
+  };
+
+  const uploadUrl = createUploadPath(origin, engine.name);
+
+  engine.fileUploadUrlCache.set(uploadUrl, uploadUrlMeta);
+
+  return new Response(JSON.stringify({ uploadUrl: [uploadUrl] }));
 }
 
 export async function handleFileUpload(
   request: Request,
-  typegraphName: string,
+  engine: QueryEngine,
 ) {
   const url = new URL(request.url);
-  if (request.method !== "POST") {
+  if (request.method !== "PUT") {
     throw new Error(
       `${url.pathname} does not support ${request.method} method`,
     );
   }
 
-  const fileStorageDir = `metatype_artifacts/${typegraphName}/files`;
-  const { name, fileHash, fileSizeInBytes, file }: TypegraphFile = await request
-    .json();
+  const uploadMeta = engine.fileUploadUrlCache.get(url.toString());
 
-  const fileData = Uint8Array.from(atob(file), (c) => c.charCodeAt(0));
-
-  if (fileData.length !== fileSizeInBytes) {
-    throw new Error();
+  if (!uploadMeta) {
+    throw new Error(`Endpoint ${url.toString()} does not exist`);
   }
 
+  const { fileName, fileHash, fileSizeInBytes, urlUsed }: UploadUrlMeta =
+    uploadMeta!;
+
+  if (urlUsed) {
+    throw new Error(`Endpoint ${url.toString()} is disabled`);
+  }
+
+  const reader = request.body?.getReader()!;
+
+  let fileData = new Uint8Array();
+  let bytesRead = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (value) {
+      bytesRead += value.length;
+      const temp = new Uint8Array(fileData.length + value.length);
+      temp.set(fileData);
+      temp.set(value, fileData.length);
+      fileData = temp;
+    }
+  }
+
+  if (bytesRead !== fileSizeInBytes) {
+    throw new Error("File size does not match");
+  }
+
+  const fileStorageDir = `metatype_artifacts/${engine.name}/files`;
   await Deno.mkdir(fileStorageDir, { recursive: true });
-  const filePath = `${fileStorageDir}/${name}.${fileHash}`;
+  const filePath = `${fileStorageDir}/${fileName}.${fileHash}`;
   await Deno.writeFile(filePath, fileData);
+
+  // mark as the url used once the request completes.
+  uploadMeta.urlUsed = true;
+  engine.fileUploadUrlCache.set(url.toString(), uploadMeta);
 
   return new Response();
 }

--- a/typegate/src/services/file_upload_service.ts
+++ b/typegate/src/services/file_upload_service.ts
@@ -1,0 +1,50 @@
+// Copyright Metatype OÜ, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+function createUploadPath(origin: string, typegraphName: string) {
+  const rand_path = crypto.randomUUID();
+  return `${origin}/${typegraphName}/files/${rand_path}`;
+}
+
+export function handleUploadUrl(request: Request, typegraphName: string) {
+  const url = new URL(request.url);
+  const origin = url.origin;
+
+  const uploadUrl = createUploadPath(origin, typegraphName);
+  return new Response(uploadUrl);
+}
+
+interface TypegraphFile {
+  name: string;
+  fileHash: string;
+  fileSizeInBytes: number;
+  file: string;
+}
+
+export async function handleFileUpload(
+  request: Request,
+  typegraphName: string,
+) {
+  const url = new URL(request.url);
+  if (request.method !== "POST") {
+    throw new Error(
+      `${url.pathname} does not support ${request.method} method`,
+    );
+  }
+
+  const fileStorageDir = `metatype_artifacts/${typegraphName}/files`;
+  const { name, fileHash, fileSizeInBytes, file }: TypegraphFile = await request
+    .json();
+
+  const fileData = Uint8Array.from(atob(file), (c) => c.charCodeAt(0));
+
+  if (fileData.length !== fileSizeInBytes) {
+    throw new Error();
+  }
+
+  await Deno.mkdir(fileStorageDir, { recursive: true });
+  const filePath = `${fileStorageDir}/${name}.${fileHash}`;
+  await Deno.writeFile(filePath, fileData);
+
+  return new Response();
+}

--- a/typegate/src/typegate/mod.ts
+++ b/typegate/src/typegate/mod.ts
@@ -134,11 +134,11 @@ export class Typegate {
       }
 
       if (serviceName === "get-upload-url") {
-        return handleUploadUrl(request, engineName);
+        return handleUploadUrl(request, engine);
       }
 
       if (serviceName === "upload-files") {
-        return handleFileUpload(request, engineName);
+        return handleFileUpload(request, engine);
       }
 
       if (serviceName === "auth") {

--- a/typegate/src/typegate/mod.ts
+++ b/typegate/src/typegate/mod.ts
@@ -35,6 +35,10 @@ import { MigrationFailure } from "../runtimes/prisma/hooks/run_migrations.ts";
 import introspectionJson from "../typegraphs/introspection.json" with {
   type: "json",
 };
+import {
+  handleFileUpload,
+  handleUploadUrl,
+} from "../services/file_upload_service.ts";
 
 const INTROSPECTION_JSON_STR = JSON.stringify(introspectionJson);
 
@@ -127,6 +131,14 @@ export class Typegate {
         return new Response(null, {
           headers: cors,
         });
+      }
+
+      if (serviceName === "get-upload-url") {
+        return handleUploadUrl(request, engineName);
+      }
+
+      if (serviceName === "upload-files") {
+        return handleFileUpload(request, engineName);
       }
 
       if (serviceName === "auth") {

--- a/typegate/src/typegraph/types.ts
+++ b/typegate/src/typegraph/types.ts
@@ -507,6 +507,7 @@ export interface TypeMeta {
   rate?: Rate | null;
   version: string;
   random_seed: number | undefined;
+  ref_files: Map<string, string>;
 }
 export interface Queries {
   dynamic: boolean;

--- a/typegate/src/typegraphs/introspection.json
+++ b/typegate/src/typegraphs/introspection.json
@@ -979,6 +979,7 @@
     },
     "auths": [],
     "rate": null,
+    "ref_files": {},
     "version": "0.0.3"
   }
 }

--- a/typegate/src/typegraphs/typegate.json
+++ b/typegate/src/typegraphs/typegate.json
@@ -944,6 +944,7 @@
       "context_identifier": "user",
       "local_excess": 5
     },
+    "ref_files": {},
     "version": "0.0.3"
   }
 }

--- a/typegraph/core/src/conversion/runtimes.rs
+++ b/typegraph/core/src/conversion/runtimes.rs
@@ -297,8 +297,7 @@ impl MaterializerConverter for WasiMaterializer {
         }))
         .map_err(|e| e.to_string())?;
 
-        // add reference file to meta.ref_files
-        c.add_ref_files(mat.artifact_hash.clone(), mat.module.clone());
+        c.add_ref_files(mat.artifact_hash.clone(), mat.module.clone().into());
 
         let name = "wasi".to_string();
         Ok(Materializer {

--- a/typegraph/core/src/conversion/runtimes.rs
+++ b/typegraph/core/src/conversion/runtimes.rs
@@ -292,9 +292,13 @@ impl MaterializerConverter for WasiMaterializer {
 
         let data = serde_json::from_value(json!({
             "wasm": mat.module,
-            "func": mat.func_name
+            "func": mat.func_name,
+            "artifact_hash": mat.artifact_hash
         }))
         .map_err(|e| e.to_string())?;
+
+        // add reference file to meta.ref_files
+        c.add_ref_files(mat.artifact_hash.clone(), mat.module.clone());
 
         let name = "wasi".to_string();
         Ok(Materializer {

--- a/typegraph/core/src/lib.rs
+++ b/typegraph/core/src/lib.rs
@@ -541,6 +541,16 @@ impl wit::core::Guest for Lib {
     fn set_seed(seed: Option<u32>) -> Result<()> {
         typegraph::set_seed(seed)
     }
+
+    fn get_ref_files() -> Result<Vec<(String, String)>, ()> {
+        let result: Vec<(String, String)> = typegraph::get_ref_files()
+            .unwrap()
+            .iter()
+            .map(|(hash, path)| (hash.clone(), path.to_string_lossy().to_string()))
+            .collect();
+
+        Ok(result)
+    }
 }
 
 #[macro_export]

--- a/typegraph/core/src/typegraph.rs
+++ b/typegraph/core/src/typegraph.rs
@@ -110,6 +110,7 @@ pub fn init(params: TypegraphInitParams) -> Result<()> {
             rate: params.rate.map(|v| v.into()),
             secrets: vec![],
             random_seed: Default::default(),
+            ref_files: Default::default(),
         },
         types: vec![],
         saved_store_state: Some(Store::save()),
@@ -211,6 +212,7 @@ pub fn finalize(mode: TypegraphFinalizeMode) -> Result<String> {
                 dynamic: ctx.meta.queries.dynamic,
                 endpoints: Store::get_graphql_endpoints(),
             },
+            ref_files: ctx.meta.ref_files,
             random_seed: Store::get_random_seed(),
             auths,
             ..ctx.meta
@@ -449,5 +451,9 @@ impl TypegraphContext {
 
     pub fn get_prisma_typegen_cache(&self) -> Rc<RefCell<HashMap<String, TypeId>>> {
         Rc::clone(&self.runtime_contexts.prisma_typegen_cache)
+    }
+
+    pub fn add_ref_files(&mut self, file_hash: String, file: String) {
+        self.meta.ref_files.insert(file_hash, file);
     }
 }

--- a/typegraph/core/src/typegraph.rs
+++ b/typegraph/core/src/typegraph.rs
@@ -26,6 +26,7 @@ use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use crate::wit::core::{
@@ -311,6 +312,10 @@ pub fn expose(
     })?
 }
 
+pub fn get_ref_files() -> Result<HashMap<String, PathBuf>> {
+    Ok(with_tg(|tg| tg.meta.ref_files.clone()).unwrap())
+}
+
 pub fn set_seed(seed: Option<u32>) -> Result<()> {
     Store::set_random_seed(seed);
     Ok(())
@@ -453,7 +458,7 @@ impl TypegraphContext {
         Rc::clone(&self.runtime_contexts.prisma_typegen_cache)
     }
 
-    pub fn add_ref_files(&mut self, file_hash: String, file: String) {
+    pub fn add_ref_files(&mut self, file_hash: String, file: PathBuf) {
         self.meta.ref_files.insert(file_hash, file);
     }
 }

--- a/typegraph/core/wit/typegraph.wit
+++ b/typegraph/core/wit/typegraph.wit
@@ -363,6 +363,7 @@ interface runtimes {
     record materializer-wasi {
         func-name: string,
         module: string,
+        artifact-hash: string,
     }
 
     register-wasmedge-runtime: func() -> result<runtime-id, error>

--- a/typegraph/core/wit/typegraph.wit
+++ b/typegraph/core/wit/typegraph.wit
@@ -218,6 +218,8 @@ interface core {
     expose: func(fns: list<tuple<string, type-id>>, default-policy: option<list<policy-spec>>) -> result<_, error>
 
     set-seed: func(seed: option<u32>) -> result<_, error>
+
+    get-ref-files: func() -> result<list<tuple<string, string>>>
     
     type runtime-id = u32
     type materializer-id = u32

--- a/typegraph/node/sdk/src/runtimes/wasmedge.ts
+++ b/typegraph/node/sdk/src/runtimes/wasmedge.ts
@@ -6,6 +6,7 @@ import { runtimes } from "../wit.js";
 import { Effect } from "../gen/interfaces/metatype-typegraph-runtimes.js";
 import { Materializer, Runtime } from "./mod.js";
 import { fx } from "../index.js";
+import { getFileHash } from "../utils/file_utils.js";
 
 interface WasiMat extends Materializer {
   module: string;
@@ -30,6 +31,13 @@ export class WasmEdgeRuntime extends Runtime {
       effect?: Effect;
     },
   ): t.Func<I, O, WasiMat> {
+    let fileHash = "";
+    getFileHash(wasm).then((hash) => {
+      fileHash = hash;
+    }).catch((err) => {
+      console.error(err);
+    });
+
     const matId = runtimes.fromWasiModule(
       {
         runtime: this._id,
@@ -38,6 +46,7 @@ export class WasmEdgeRuntime extends Runtime {
       {
         module: `file:${wasm}`,
         funcName: func,
+        artifactHash: fileHash,
       },
     );
 

--- a/typegraph/node/sdk/src/utils/file_utils.ts
+++ b/typegraph/node/sdk/src/utils/file_utils.ts
@@ -1,0 +1,44 @@
+// Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
+// SPDX-License-Identifier: MPL-2.0
+
+import * as fs from "fs";
+import * as crypto from "crypto";
+
+export function getFileHash(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha256");
+    const fileDescriptor = fs.openSync(filePath, "r");
+
+    const CHUNK_SIZE = 4096;
+    let buffer = Buffer.alloc(CHUNK_SIZE);
+    let bytesRead = 0;
+
+    function readChunk() {
+      fs.read(
+        fileDescriptor,
+        buffer,
+        0,
+        CHUNK_SIZE,
+        bytesRead,
+        (err, bytesRead) => {
+          if (err) {
+            fs.closeSync(fileDescriptor);
+            reject(err);
+            return;
+          }
+
+          if (bytesRead === 0) {
+            fs.closeSync(fileDescriptor);
+            resolve(hash.digest("hex"));
+            return;
+          }
+
+          hash.update(buffer.subarray(0, bytesRead));
+          readChunk();
+        },
+      );
+    }
+
+    readChunk();
+  });
+}

--- a/typegraph/python/typegraph/graph/tg_deploy.py
+++ b/typegraph/python/typegraph/graph/tg_deploy.py
@@ -1,17 +1,17 @@
 # Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
 # SPDX-License-Identifier: MPL-2.0
 
+import json
+from base64 import b64encode
 from dataclasses import dataclass
 from typing import Dict, Optional, Union
 from urllib import request
-import json
-from base64 import b64encode
-from typegraph.gen.exports.core import ArtifactResolutionConfig
-from typegraph.gen.types import Err
 
-from typegraph.graph.typegraph import TypegraphOutput
+from typegraph.gen.exports.core import ArtifactResolutionConfig
 from typegraph.gen.exports.utils import QueryDeployParams
-from typegraph.wit import store, wit_utils
+from typegraph.gen.types import Err
+from typegraph.graph.typegraph import TypegraphOutput
+from typegraph.wit import core, store, wit_utils
 
 
 @dataclass
@@ -52,6 +52,13 @@ class RemoveResult:
     typegate: Union[Dict[str, any], str]
 
 
+@dataclass
+class UploadArtifactMeta:
+    name: str
+    file_hash: str
+    file_size_in_bytes: int
+
+
 def tg_deploy(tg: TypegraphOutput, params: TypegraphDeployParams) -> DeployResult:
     sep = "/" if not params.base_url.endswith("/") else ""
     url = params.base_url + sep + "typegate"
@@ -60,6 +67,35 @@ def tg_deploy(tg: TypegraphOutput, params: TypegraphDeployParams) -> DeployResul
     if params.auth is not None:
         headers["Authorization"] = params.auth.as_header_value()
     serialized = tg.serialize(params.artifacts_config)
+
+    # upload the referred files
+    ref_files = core.get_ref_files(store)
+    if isinstance(ref_files, Err):
+        raise Exception(ref_files.value)
+
+    get_upload_url = params.base_url + sep + "get-upload-url"
+    for file_hash, file_path in ref_files.value:
+        with open(file_path, "rb") as file:
+            file_content = file.read()
+            artifact = UploadArtifactMeta(
+                name=file.name,
+                file_hash=file_hash,
+                file_size_in_bytes=len(file_content),
+            )
+            req = request.Request(
+                url=get_upload_url, method="GET", headers=headers, data=artifact
+            )
+
+            response = handle_response(request.urlopen(req).read().decode())
+            file_upload_url = response["uploadUrl"]
+            upload_req = request.Request(
+                url=file_upload_url,
+                method="PUT",
+                data=file_content,
+                headers={"Content-Type": "application/octet-stream"},
+            )
+            response = request.urlopen(upload_req)
+
     res = wit_utils.gql_deploy_query(
         store,
         params=QueryDeployParams(

--- a/typegraph/python/typegraph/graph/tg_deploy.py
+++ b/typegraph/python/typegraph/graph/tg_deploy.py
@@ -73,6 +73,7 @@ def tg_deploy(tg: TypegraphOutput, params: TypegraphDeployParams) -> DeployResul
     if isinstance(ref_files, Err):
         raise Exception(ref_files.value)
 
+    # TODO: fetch all the upload by one request
     get_upload_url = params.base_url + sep + "get-upload-url"
     for file_hash, file_path in ref_files.value:
         with open(file_path, "rb") as file:

--- a/typegraph/python/typegraph/runtimes/wasmedge.py
+++ b/typegraph/python/typegraph/runtimes/wasmedge.py
@@ -12,6 +12,7 @@ from typegraph.gen.exports.runtimes import (
 )
 from typegraph.gen.types import Err
 from typegraph.runtimes.base import Materializer, Runtime
+from typegraph.utils import get_file_hash
 from typegraph.wit import runtimes, store
 
 
@@ -29,12 +30,13 @@ class WasmEdgeRuntime(Runtime):
         effect: Optional[Effect] = None,
     ):
         effect = effect or EffectRead()
+        file_hash = get_file_hash(wasm)
         wasm = f"file:{wasm}"
 
         mat_id = runtimes.from_wasi_module(
             store,
             BaseMaterializer(runtime=self.id.value, effect=effect),
-            MaterializerWasi(module=wasm, func_name=func),
+            MaterializerWasi(module=wasm, func_name=func, artifact_hash=file_hash),
         )
 
         if isinstance(mat_id, Err):

--- a/typegraph/python/typegraph/utils.py
+++ b/typegraph/python/typegraph/utils.py
@@ -1,7 +1,10 @@
 # Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
 # SPDX-License-Identifier: MPL-2.0
 
+import hashlib
 import json
+import os
+import sys
 from functools import reduce
 from typing import Dict, List, Union, Tuple, Optional, Any
 from typegraph.injection import InheritDef
@@ -77,3 +80,17 @@ def build_reduce_data(node: Any, paths: List[ReducePath], curr_path: List[str]):
 
 def unpack_tarb64(tar_b64: str, dest: str):
     return wit_utils.unpack_tarb64(store, tar_b64, dest)
+
+
+def get_file_hash(file_path: str) -> str:
+    sha256_hasher = hashlib.sha256()
+
+    curr_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+    file_dir = os.path.join(curr_dir, file_path)
+
+    with open(file_dir, "rb") as file:
+        chunk = 0
+        while chunk := file.read(4096):
+            sha256_hasher.update(chunk)
+
+    return sha256_hasher.hexdigest()


### PR DESCRIPTION
Upload protocol for wasm files and atrifacts for `WasmEdge Runtime` for single replica mode

#### Motivation and context

- Store WasmEdge Runtime artifacts in the file system during typegraph finalization
- Access and load WasmEdge Runtime artifacts from the local file system

#### Migration notes

*No Migrations Needed*

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
