### PR TITLE
refactor: pass test options in the first parameter

### DIFF
--- a/typegate/tests/e2e/cli/deploy_test.ts
+++ b/typegate/tests/e2e/cli/deploy_test.ts
@@ -75,301 +75,297 @@ async function deploy(
   }
 }
 
-Meta.test(
-  "meta deploy: fails migration for new columns without default value",
-  async (t) => {
-    const schema = randomSchema();
-    const secrets = {
-      TG_MIGRATION_FAILURE_TEST_PROGRES:
-        `postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-    };
-    await t.should("load first version of the typegraph", async () => {
-      await reset(tgName, schema);
-      await writeTypegraph(null);
-    });
+Meta.test({
+  name: "meta deploy: fails migration for new columns without default value",
+  port: true,
+  systemTypegraphs: true,
+}, async (t) => {
+  const schema = randomSchema();
+  const secrets = {
+    TG_MIGRATION_FAILURE_TEST_PROGRES:
+      `postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
+  };
+  await t.should("load first version of the typegraph", async () => {
+    await reset(tgName, schema);
+    await writeTypegraph(null);
+  });
 
-    const port = t.port!;
+  const port = t.port!;
 
-    // `deploy` must be run outside of the `should` block,
-    // otherwise this would fail by leaking ops.
-    // That is expected since it creates new engine that persists beyond the
-    // `should` block.
-    await deploy({ port, secrets });
+  // `deploy` must be run outside of the `should` block,
+  // otherwise this would fail by leaking ops.
+  // That is expected since it creates new engine that persists beyond the
+  // `should` block.
+  await deploy({ port, secrets });
 
-    await t.should("insert records", async () => {
-      const e = t.getTypegraphEngine(tgName);
-      if (!e) {
-        throw new Error("typegraph not found");
-      }
-
-      await gql`
-        mutation {
-          createRecord(data: {}) {
-            id
-          }
-        }
-      `
-        .expectData({
-          createRecord: {
-            id: 1,
-          },
-        })
-        .on(e);
-    });
-
-    await t.should("load second version of the typegraph", async () => {
-      await writeTypegraph(1);
-    });
-
-    try {
-      await reset(tgName, schema);
-      await deploy({ port, secrets });
-    } catch (e) {
-      assertStringIncludes(
-        e.message,
-        // 'column "age" of relation "Record" contains null values: set a default value:',
-        'column "age" of relation "Record" contains null values',
-      );
+  await t.should("insert records", async () => {
+    const e = t.getTypegraphEngine(tgName);
+    if (!e) {
+      throw new Error("typegraph not found");
     }
-  },
-  { port: true, systemTypegraphs: true },
-);
 
-Meta.test(
-  "meta deploy: succeeds migration for new columns with default value",
-  async (t) => {
-    const port = t.port!;
-    const schema = randomSchema();
-    const secrets = {
-      TG_MIGRATION_FAILURE_TEST_POSTGRES:
+    await gql`
+      mutation {
+        createRecord(data: {}) {
+          id
+        }
+      }
+    `
+      .expectData({
+        createRecord: {
+          id: 1,
+        },
+      })
+      .on(e);
+  });
+
+  await t.should("load second version of the typegraph", async () => {
+    await writeTypegraph(1);
+  });
+
+  try {
+    await reset(tgName, schema);
+    await deploy({ port, secrets });
+  } catch (e) {
+    assertStringIncludes(
+      e.message,
+      // 'column "age" of relation "Record" contains null values: set a default value:',
+      'column "age" of relation "Record" contains null values',
+    );
+  }
+});
+
+Meta.test({
+  name: "meta deploy: succeeds migration for new columns with default value",
+  port: true,
+  systemTypegraphs: true,
+}, async (t) => {
+  const port = t.port!;
+  const schema = randomSchema();
+  const secrets = {
+    TG_MIGRATION_FAILURE_TEST_POSTGRES:
+      `postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
+  };
+  await t.should("load first version of the typegraph", async () => {
+    await reset(tgName, schema);
+    await writeTypegraph(null);
+  });
+
+  await deploy({ port, secrets });
+
+  await t.should("insert records", async () => {
+    const e = t.getTypegraphEngine(tgName)!;
+
+    await gql`
+      mutation {
+        createRecord(data: {}) {
+          id
+        }
+      }
+    `
+      .expectData({
+        createRecord: {
+          id: 1,
+        },
+      })
+      .on(e);
+  });
+
+  await t.should("load second version of the typegraph", async () => {
+    await writeTypegraph(3); // int
+  });
+
+  await deploy({ port, secrets });
+
+  await t.should("load third version of the typegraph", async () => {
+    await writeTypegraph(4); // string
+  });
+
+  await deploy({ port, secrets });
+});
+
+Meta.test({
+  name: "cli:deploy - automatic migrations",
+  systemTypegraphs: true,
+  port: true,
+
+  gitRepo: {
+    content: {
+      "prisma.py": "runtimes/prisma/prisma.py",
+      "metatype.yml": "metatype.yml",
+    },
+  },
+}, async (t) => {
+  const port = t.port!;
+  const schema = randomSchema();
+  const e = await t.engine("prisma.py", {
+    secrets: {
+      POSTGRES:
         `postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-    };
-    await t.should("load first version of the typegraph", async () => {
-      await reset(tgName, schema);
-      await writeTypegraph(null);
-    });
+    },
+  });
 
-    await deploy({ port, secrets });
+  await dropSchemas(e);
+  await removeMigrations(e);
 
-    await t.should("insert records", async () => {
-      const e = t.getTypegraphEngine(tgName)!;
+  const nodeConfigs = [
+    "--target",
+    "dev",
+    "--gate",
+    `http://localhost:${port}`,
+    "--secret",
+    `TG_PRISMA_PROGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
+  ];
 
-      await gql`
-        mutation {
-          createRecord(data: {}) {
-            id
-          }
+  await t.should("fail to access database", async () => {
+    await gql`
+      query {
+        findManyRecords {
+          id
         }
-      `
-        .expectData({
-          createRecord: {
-            id: 1,
-          },
-        })
-        .on(e);
-    });
+      }
+    `
+      .expectErrorContains(`table \`${schema}.record\` does not exist`)
+      .on(e);
+  });
 
-    await t.should("load second version of the typegraph", async () => {
-      await writeTypegraph(3); // int
-    });
-
-    await deploy({ port, secrets });
-
-    await t.should("load third version of the typegraph", async () => {
-      await writeTypegraph(4); // string
-    });
-
-    await deploy({ port, secrets });
-  },
-  { port: true, systemTypegraphs: true },
-);
-
-Meta.test(
-  "cli:deploy - automatic migrations",
-  async (t) => {
-    const port = t.port!;
-    const schema = randomSchema();
-    const e = await t.engine("prisma.py", {
-      secrets: {
-        POSTGRES:
-          `postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-      },
-    });
-
-    await dropSchemas(e);
-    await removeMigrations(e);
-
-    const nodeConfigs = [
-      "--target",
-      "dev",
-      "--gate",
-      `http://localhost:${port}`,
-      "--secret",
-      `TG_PRISMA_PROGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-    ];
-
-    await t.should("fail to access database", async () => {
-      await gql`
-        query {
-          findManyRecords {
-            id
-          }
-        }
-      `
-        .expectErrorContains(`table \`${schema}.record\` does not exist`)
-        .on(e);
-    });
-
-    await t.should("fail on dirty repo", async () => {
-      await t.shell(["bash", "-c", "touch README.md"]);
-      await assertRejects(() =>
-        t.meta(["deploy", ...nodeConfigs, "-f", "prisma.py"])
-      );
-    });
-
-    await t.should("commit changes", async () => {
-      await t.shell(["git", "add", "."]);
-      await t.shell(["git", "commit", "-m", "create migrations"]);
-    });
-
-    // not in t.should because it creates a worker that will not be closed
-    await t.meta([
-      "deploy",
-      ...nodeConfigs,
-      "-f",
-      "prisma.py",
-      "--create-migration",
-    ]);
-
-    await t.should(
-      "succeed have replaced and terminated the previous engine",
-      async () => {
-        await gql`
-          query {
-            findManyRecords {
-              id
-            }
-          }
-        `
-          .expectErrorContains("Could not find engine")
-          .on(e);
-      },
+  await t.should("fail on dirty repo", async () => {
+    await t.shell(["bash", "-c", "touch README.md"]);
+    await assertRejects(() =>
+      t.meta(["deploy", ...nodeConfigs, "-f", "prisma.py"])
     );
+  });
 
-    const e2 = t.getTypegraphEngine("prisma")!;
+  await t.should("commit changes", async () => {
+    await t.shell(["git", "add", "."]);
+    await t.shell(["git", "commit", "-m", "create migrations"]);
+  });
 
-    await t.should("succeed to query database", async () => {
+  // not in t.should because it creates a worker that will not be closed
+  await t.meta([
+    "deploy",
+    ...nodeConfigs,
+    "-f",
+    "prisma.py",
+    "--create-migration",
+  ]);
+
+  await t.should(
+    "succeed have replaced and terminated the previous engine",
+    async () => {
       await gql`
         query {
           findManyRecords {
             id
-            name
           }
         }
       `
-        .expectData({
-          findManyRecords: [],
-        })
-        .on(e2);
-    });
-  },
-  {
-    systemTypegraphs: true,
-    port: true,
-    gitRepo: {
-      content: {
-        "prisma.py": "runtimes/prisma/prisma.py",
-        "metatype.yml": "metatype.yml",
-      },
+        .expectErrorContains("Could not find engine")
+        .on(e);
+    },
+  );
+
+  const e2 = t.getTypegraphEngine("prisma")!;
+
+  await t.should("succeed to query database", async () => {
+    await gql`
+      query {
+        findManyRecords {
+          id
+          name
+        }
+      }
+    `
+      .expectData({
+        findManyRecords: [],
+      })
+      .on(e2);
+  });
+});
+
+Meta.test({
+  name: "cli:deploy - with prefix",
+  systemTypegraphs: true,
+  port: true,
+
+  gitRepo: {
+    content: {
+      "prisma.py": "runtimes/prisma/prisma.py",
+      "metatype.yml": "metatype.yml",
     },
   },
-);
-
-Meta.test(
-  "cli:deploy - with prefix",
-  async (t) => {
-    const schema = randomSchema();
-    const e = await t.engine("prisma.py", {
-      secrets: {
-        POSTGRES:
-          `postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-      },
-      prefix: "pref-",
-    });
-
-    await dropSchemas(e);
-    await removeMigrations(e);
-
-    const nodeConfigs = [
-      "-t",
-      "with_prefix",
-      "--gate",
-      `http://localhost:${t.port}`,
-      "--secret",
-      `TG_PRISMA_PROGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-    ];
-
-    await t.should("fail to access database", async () => {
-      await gql`
-        query {
-          findManyRecords {
-            id
-          }
-        }
-      `
-        .expectErrorContains(`table \`${schema}.record\` does not exist`)
-        .on(e);
-    });
-
-    // not in t.should because it creates a worker that will not be closed
-    await t.meta([
-      "deploy",
-      ...nodeConfigs,
-      "-f",
-      "prisma.py",
-      "--create-migration",
-    ]);
-
-    await t.should(
-      "succeed have replaced and terminated the previous engine",
-      async () => {
-        await gql`
-          query {
-            findManyRecords {
-              id
-            }
-          }
-        `
-          .expectErrorContains("Could not find engine")
-          .on(e);
-      },
-    );
-
-    const e2 = t.getTypegraphEngine("pref-prisma")!;
-
-    await t.should("succeed to query database", async () => {
-      await gql`
-        query {
-          findManyRecords {
-            id
-            name
-          }
-        }
-      `
-        .expectData({
-          findManyRecords: [],
-        })
-        .on(e2);
-    });
-  },
-  {
-    systemTypegraphs: true,
-    port: true,
-    gitRepo: {
-      content: {
-        "prisma.py": "runtimes/prisma/prisma.py",
-        "metatype.yml": "metatype.yml",
-      },
+}, async (t) => {
+  const schema = randomSchema();
+  const e = await t.engine("prisma.py", {
+    secrets: {
+      POSTGRES:
+        `postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
     },
-  },
-);
+    prefix: "pref-",
+  });
+
+  await dropSchemas(e);
+  await removeMigrations(e);
+
+  const nodeConfigs = [
+    "-t",
+    "with_prefix",
+    "--gate",
+    `http://localhost:${t.port}`,
+    "--secret",
+    `TG_PRISMA_PROGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
+  ];
+
+  await t.should("fail to access database", async () => {
+    await gql`
+      query {
+        findManyRecords {
+          id
+        }
+      }
+    `
+      .expectErrorContains(`table \`${schema}.record\` does not exist`)
+      .on(e);
+  });
+
+  // not in t.should because it creates a worker that will not be closed
+  await t.meta([
+    "deploy",
+    ...nodeConfigs,
+    "-f",
+    "prisma.py",
+    "--create-migration",
+  ]);
+
+  await t.should(
+    "succeed have replaced and terminated the previous engine",
+    async () => {
+      await gql`
+        query {
+          findManyRecords {
+            id
+          }
+        }
+      `
+        .expectErrorContains("Could not find engine")
+        .on(e);
+    },
+  );
+
+  const e2 = t.getTypegraphEngine("pref-prisma")!;
+
+  await t.should("succeed to query database", async () => {
+    await gql`
+      query {
+        findManyRecords {
+          id
+          name
+        }
+      }
+    `
+      .expectData({
+        findManyRecords: [],
+      })
+      .on(e2);
+  });
+});

--- a/typegate/tests/e2e/cli/dev_test.ts
+++ b/typegate/tests/e2e/cli/dev_test.ts
@@ -31,103 +31,101 @@ async function writeTypegraph(version: number | null, target = "migration.py") {
   }
 }
 
-Meta.test(
-  "meta dev: choose to reset the database",
-  async (t) => {
-    const schema = randomSchema();
-    const tgDefPath = join(t.workingDir, "migration.py");
+Meta.test({
+  name: "meta dev: choose to reset the database",
+  port: true,
+  systemTypegraphs: true,
 
-    await t.should("load first version of the typegraph", async () => {
-      await reset(tgName, schema);
-      await writeTypegraph(null, tgDefPath);
-    });
-
-    const metadev = await MetaDev.start({
-      cwd: t.workingDir,
-      args: [
-        "dev",
-        "--target=dev",
-        `--gate=http://localhost:${t.port}`,
-        "--secret",
-        `TG_MIGRATION_FAILURE_TEST_POSTGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-      ],
-    });
-
-    await metadev.fetchStderrLines((line) => {
-      console.log("line:", line);
-      return !line.includes(
-        "Successfully pushed typegraph migration-failure-test",
-      );
-    });
-
-    await t.should("insert records", async () => {
-      const e = t.getTypegraphEngine(tgName);
-      if (!e) {
-        throw new Error("typegraph not found");
-      }
-      await gql`
-        mutation {
-          createRecord(data: {}) {
-            id
-          }
-        }
-      `
-        .expectData({
-          createRecord: {
-            id: 1,
-          },
-        })
-        .on(e);
-    });
-
-    await t.should("load second version of the typegraph", async () => {
-      await writeTypegraph(1, tgDefPath);
-      await metadev.fetchStderrLines((line) => {
-        console.log("line:", line);
-        return !line.includes("[select]");
-      });
-
-      await metadev.writeLine("3");
-    });
-
-    await metadev.fetchStderrLines((line) => {
-      console.log("line:", line);
-      return !line.includes(
-        "Successfully pushed typegraph migration-failure-test",
-      );
-    });
-
-    await t.should("database be empty", async () => {
-      const e = t.getTypegraphEngine(tgName);
-      if (!e) {
-        throw new Error("typegraph not found");
-      }
-      await gql`
-        query {
-          findRecords {
-            id
-            age
-          }
-        }
-      `
-        .expectData({
-          findRecords: [],
-        })
-        .on(e);
-    });
-
-    await metadev.close();
-  },
-  {
-    port: true,
-    systemTypegraphs: true,
-    gitRepo: {
-      content: {
-        "metatype.yml": "metatype.yml",
-      },
+  gitRepo: {
+    content: {
+      "metatype.yml": "metatype.yml",
     },
   },
-);
+}, async (t) => {
+  const schema = randomSchema();
+  const tgDefPath = join(t.workingDir, "migration.py");
+
+  await t.should("load first version of the typegraph", async () => {
+    await reset(tgName, schema);
+    await writeTypegraph(null, tgDefPath);
+  });
+
+  const metadev = await MetaDev.start({
+    cwd: t.workingDir,
+    args: [
+      "dev",
+      "--target=dev",
+      `--gate=http://localhost:${t.port}`,
+      "--secret",
+      `TG_MIGRATION_FAILURE_TEST_POSTGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
+    ],
+  });
+
+  await metadev.fetchStderrLines((line) => {
+    console.log("line:", line);
+    return !line.includes(
+      "Successfully pushed typegraph migration-failure-test",
+    );
+  });
+
+  await t.should("insert records", async () => {
+    const e = t.getTypegraphEngine(tgName);
+    if (!e) {
+      throw new Error("typegraph not found");
+    }
+    await gql`
+      mutation {
+        createRecord(data: {}) {
+          id
+        }
+      }
+    `
+      .expectData({
+        createRecord: {
+          id: 1,
+        },
+      })
+      .on(e);
+  });
+
+  await t.should("load second version of the typegraph", async () => {
+    await writeTypegraph(1, tgDefPath);
+    await metadev.fetchStderrLines((line) => {
+      console.log("line:", line);
+      return !line.includes("[select]");
+    });
+
+    await metadev.writeLine("3");
+  });
+
+  await metadev.fetchStderrLines((line) => {
+    console.log("line:", line);
+    return !line.includes(
+      "Successfully pushed typegraph migration-failure-test",
+    );
+  });
+
+  await t.should("database be empty", async () => {
+    const e = t.getTypegraphEngine(tgName);
+    if (!e) {
+      throw new Error("typegraph not found");
+    }
+    await gql`
+      query {
+        findRecords {
+          id
+          age
+        }
+      }
+    `
+      .expectData({
+        findRecords: [],
+      })
+      .on(e);
+  });
+
+  await metadev.close();
+});
 
 async function listSubdirs(path: string): Promise<string[]> {
   const subdirs: string[] = [];
@@ -139,103 +137,101 @@ async function listSubdirs(path: string): Promise<string[]> {
   return subdirs;
 }
 
-Meta.test(
-  "meta dev: remove latest migration",
-  async (t) => {
-    const schema = randomSchema();
-    const tgDefFile = join(t.workingDir, "migration.py");
+Meta.test({
+  name: "meta dev: remove latest migration",
+  port: true,
+  systemTypegraphs: true,
 
-    await t.should("have no migration file", async () => {
-      await assertRejects(() =>
-        Deno.lstat(resolve(t.workingDir, "prisma-migrations"))
-      );
-    });
-
-    await t.should("load first version of the typegraph", async () => {
-      await reset(tgName, schema);
-      await writeTypegraph(null, tgDefFile);
-    });
-
-    const metadev = await MetaDev.start({
-      cwd: t.workingDir,
-      args: [
-        "dev",
-        "--target=dev",
-        `--gate=http://localhost:${t.port}`,
-        `--secret=TG_MIGRATION_FAILURE_TEST_POSTGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
-      ],
-    });
-
-    await metadev.fetchStderrLines((line) => {
-      console.log("line:", line);
-      return !line.includes(
-        "Successfully pushed typegraph migration-failure-test",
-      );
-    });
-
-    await t.should("have created migration", async () => {
-      await Deno.lstat(resolve(t.workingDir, "prisma-migrations"));
-    });
-
-    await t.should("insert records", async () => {
-      const e = t.getTypegraphEngine(tgName);
-      if (!e) {
-        throw new Error("typegraph not found");
-      }
-      await gql`
-        mutation {
-          createRecord(data: {}) {
-            id
-          }
-        }
-      `
-        .expectData({
-          createRecord: {
-            id: 1,
-          },
-        })
-        .on(e);
-    });
-
-    const migrationsDir = resolve(
-      t.workingDir,
-      "prisma-migrations",
-      "migration-failure-test/main",
-    );
-    console.log("Typegate migration dir", migrationsDir);
-
-    await t.should("load second version of the typegraph", async () => {
-      await writeTypegraph(1, tgDefFile);
-      await metadev.fetchStderrLines((line) => {
-        console.log("line:", line);
-        return !line.includes("[select]");
-      });
-
-      assert((await listSubdirs(migrationsDir)).length === 2);
-
-      await metadev.writeLine("1");
-    });
-
-    await metadev.fetchStderrLines((line) => {
-      console.log("line:", line);
-      return !line.includes(
-        "Removed migration directory",
-      );
-    });
-
-    await t.should("have removed latest migration", async () => {
-      assert((await listSubdirs(migrationsDir)).length === 1);
-    });
-
-    await metadev.close();
-  },
-  {
-    port: true,
-    systemTypegraphs: true,
-    gitRepo: {
-      content: {
-        "metatype.yml": "metatype.yml",
-      },
+  gitRepo: {
+    content: {
+      "metatype.yml": "metatype.yml",
     },
   },
-);
+}, async (t) => {
+  const schema = randomSchema();
+  const tgDefFile = join(t.workingDir, "migration.py");
+
+  await t.should("have no migration file", async () => {
+    await assertRejects(() =>
+      Deno.lstat(resolve(t.workingDir, "prisma-migrations"))
+    );
+  });
+
+  await t.should("load first version of the typegraph", async () => {
+    await reset(tgName, schema);
+    await writeTypegraph(null, tgDefFile);
+  });
+
+  const metadev = await MetaDev.start({
+    cwd: t.workingDir,
+    args: [
+      "dev",
+      "--target=dev",
+      `--gate=http://localhost:${t.port}`,
+      `--secret=TG_MIGRATION_FAILURE_TEST_POSTGRES=postgresql://postgres:password@localhost:5432/db?schema=${schema}`,
+    ],
+  });
+
+  await metadev.fetchStderrLines((line) => {
+    console.log("line:", line);
+    return !line.includes(
+      "Successfully pushed typegraph migration-failure-test",
+    );
+  });
+
+  await t.should("have created migration", async () => {
+    await Deno.lstat(resolve(t.workingDir, "prisma-migrations"));
+  });
+
+  await t.should("insert records", async () => {
+    const e = t.getTypegraphEngine(tgName);
+    if (!e) {
+      throw new Error("typegraph not found");
+    }
+    await gql`
+      mutation {
+        createRecord(data: {}) {
+          id
+        }
+      }
+    `
+      .expectData({
+        createRecord: {
+          id: 1,
+        },
+      })
+      .on(e);
+  });
+
+  const migrationsDir = resolve(
+    t.workingDir,
+    "prisma-migrations",
+    "migration-failure-test/main",
+  );
+  console.log("Typegate migration dir", migrationsDir);
+
+  await t.should("load second version of the typegraph", async () => {
+    await writeTypegraph(1, tgDefFile);
+    await metadev.fetchStderrLines((line) => {
+      console.log("line:", line);
+      return !line.includes("[select]");
+    });
+
+    assert((await listSubdirs(migrationsDir)).length === 2);
+
+    await metadev.writeLine("1");
+  });
+
+  await metadev.fetchStderrLines((line) => {
+    console.log("line:", line);
+    return !line.includes(
+      "Removed migration directory",
+    );
+  });
+
+  await t.should("have removed latest migration", async () => {
+    assert((await listSubdirs(migrationsDir)).length === 1);
+  });
+
+  await metadev.close();
+});

--- a/typegate/tests/e2e/cli/undeploy_test.ts
+++ b/typegate/tests/e2e/cli/undeploy_test.ts
@@ -7,7 +7,11 @@ import { dropSchema, randomSchema } from "test-utils/database.ts";
 
 const m = new TestModule(import.meta);
 
-Meta.test("meta undeploy", async (t) => {
+Meta.test({
+  name: "meta undeploy",
+  port: true,
+  systemTypegraphs: true,
+}, async (t) => {
   const schema = randomSchema();
   // prepare
   await dropSchema(schema);
@@ -33,4 +37,4 @@ Meta.test("meta undeploy", async (t) => {
       "migration-failure-test",
     );
   });
-}, { port: true, systemTypegraphs: true });
+});

--- a/typegate/tests/e2e/nextjs/apollo_test.ts
+++ b/typegate/tests/e2e/nextjs/apollo_test.ts
@@ -282,7 +282,12 @@ async function undeployTypegraph(port: number) {
   );
 }
 
-Meta.test("apollo client", async (t) => {
+Meta.test({
+  name: "apollo client",
+  port: true,
+  systemTypegraphs: true,
+  introspection: true
+}, async (t) => {
   await initBucket();
   await deployTypegraph(t.port!);
 
@@ -313,8 +318,4 @@ Meta.test("apollo client", async (t) => {
   }
 
   await undeployTypegraph(t.port!);
-}, {
-  port: true,
-  systemTypegraphs: true,
-  introspection: true,
 });

--- a/typegate/tests/e2e/self_deploy/self_deploy_test.ts
+++ b/typegate/tests/e2e/self_deploy/self_deploy_test.ts
@@ -8,7 +8,11 @@ import { testDir } from "test-utils/dir.ts";
 import { join } from "std/path/join.ts";
 import { assertEquals, assertExists } from "std/assert/mod.ts";
 
-Meta.test("deploy and undeploy typegraph without meta-cli", async (t) => {
+Meta.test({
+  name: "deploy and undeploy typegraph without meta-cli",
+  port: true,
+  systemTypegraphs: true,
+}, async (t) => {
   const gate = `http://localhost:${t.port}`;
   const auth = new BasicAuth("admin", "password");
   const cwdDir = join(testDir, "e2e", "self_deploy");
@@ -40,4 +44,4 @@ Meta.test("deploy and undeploy typegraph without meta-cli", async (t) => {
     auth,
   });
   assertEquals(gateResponseRem, { data: { removeTypegraphs: true } });
-}, { port: true, systemTypegraphs: true });
+});

--- a/typegate/tests/e2e/templates/templates_test.ts
+++ b/typegate/tests/e2e/templates/templates_test.ts
@@ -68,39 +68,39 @@ const modifiers: Record<string, (dir: string) => Promise<void> | void> = {
 };
 
 for (const template of ["python", "deno", "node"]) {
-  Meta.test(
-    `${template} template`,
-    async (t) => {
-      const dir = await newTempDir();
+  Meta.test({
+    name: `${template} template`,
+    port: true,
+    systemTypegraphs: true,
+  }, async (t) => {
+    const dir = await newTempDir();
 
-      await t.should("should be extracted correctly", async () => {
-        const out = await Meta.cli("new", "--template", template, dir);
-        console.log(out.stdout);
-        const source = join(workspaceDir, "examples/templates", template);
-        const sourcesFiles = await Array.fromAsync(
-          expandGlob("**/*", {
-            root: source,
-          }),
-        );
-        assert(sourcesFiles.length > 0);
-        for (const f of sourcesFiles) {
-          const relPath = f.path.replace(source, "");
-          assert(exists(join(dir, relPath)));
-        }
-      });
-
-      await modifiers[template](dir);
-      const out = await Meta.cli(
-        { currentDir: dir },
-        "deploy",
-        "--target",
-        "dev",
-        "--gate",
-        `http://localhost:${t.port}`,
-        "--allow-dirty",
+    await t.should("should be extracted correctly", async () => {
+      const out = await Meta.cli("new", "--template", template, dir);
+      console.log(out.stdout);
+      const source = join(workspaceDir, "examples/templates", template);
+      const sourcesFiles = await Array.fromAsync(
+        expandGlob("**/*", {
+          root: source,
+        }),
       );
-      console.log(out);
-    },
-    { port: true, systemTypegraphs: true },
-  );
+      assert(sourcesFiles.length > 0);
+      for (const f of sourcesFiles) {
+        const relPath = f.path.replace(source, "");
+        assert(exists(join(dir, relPath)));
+      }
+    });
+
+    await modifiers[template](dir);
+    const out = await Meta.cli(
+      { currentDir: dir },
+      "deploy",
+      "--target",
+      "dev",
+      "--gate",
+      `http://localhost:${t.port}`,
+      "--allow-dirty",
+    );
+    console.log(out);
+  });
 }

--- a/typegate/tests/internal/internal_test.ts
+++ b/typegate/tests/internal/internal_test.ts
@@ -3,7 +3,10 @@
 
 import { gql, Meta } from "../utils/mod.ts";
 
-Meta.test("Internal test", async (t) => {
+Meta.test({
+  name: "Internal test",
+  port: true,
+}, async (t) => {
   const e = await t.engine("internal/internal.py");
 
   await t.should("work on the default worker", async () => {
@@ -17,4 +20,4 @@ Meta.test("Internal test", async (t) => {
       })
       .on(e, `http://localhost:${t.port}`);
   });
-}, { port: true });
+});

--- a/typegate/tests/introspection/introspection_test.ts
+++ b/typegate/tests/introspection/introspection_test.ts
@@ -5,7 +5,10 @@ import { gql, Meta } from "../utils/mod.ts";
 
 // https://github.com/graphql/graphql-js/blob/main/src/__tests__/starWarsIntrospection-test.ts
 
-Meta.test("Basic introspection", async (t) => {
+Meta.test({
+  name: "Basic introspection",
+  introspection: true,
+}, async (t) => {
   const e = await t.engine("simple/simple.py");
 
   await t.should("allow querying the schema for types", async () => {
@@ -232,9 +235,12 @@ Meta.test("Basic introspection", async (t) => {
       })
       .on(e);
   });
-}, { introspection: true });
+});
 
-Meta.test("Full introspection", async (t) => {
+Meta.test({
+  name: "Full introspection",
+  introspection: true,
+}, async (t) => {
   const e = await t.engine("simple/simple.py");
 
   await t.should("not fail", async () => {
@@ -337,4 +343,4 @@ Meta.test("Full introspection", async (t) => {
       .matchOkSnapshot(t)
       .on(e);
   });
-}, { introspection: true });
+});

--- a/typegate/tests/introspection/union_either_test.ts
+++ b/typegate/tests/introspection/union_either_test.ts
@@ -5,7 +5,10 @@ import { gql, Meta } from "../utils/mod.ts";
 
 // https://github.com/graphql/graphql-js/blob/main/src/__tests__/starWarsIntrospection-test.ts
 
-Meta.test("Basic introspection", async (t) => {
+Meta.test({
+  name: "Basic introspection",
+  introspection: true,
+}, async (t) => {
   const e = await t.engine("introspection/union_either.py");
   await t.should("allow querying the schema for query type", async () => {
     await gql`
@@ -28,4 +31,4 @@ Meta.test("Basic introspection", async (t) => {
       .matchOkSnapshot(t)
       .on(e);
   });
-}, { introspection: true });
+});

--- a/typegate/tests/prisma_migrate/prisma_migrate_test.ts
+++ b/typegate/tests/prisma_migrate/prisma_migrate_test.ts
@@ -14,7 +14,10 @@ import { gql, Meta } from "../utils/mod.ts";
 import { dropSchemas, removeMigrations } from "../utils/migrations.ts";
 import { testDir } from "../utils/dir.ts";
 
-Meta.test("prisma migrations", async (t) => {
+Meta.test({
+  name: "prisma migrations",
+  systemTypegraphs: true,
+}, async (t) => {
   const tgPath = "runtimes/prisma/prisma.py";
   const migrations = t.getTypegraphEngine("typegate/prisma_migration")!;
   assertExists(migrations);
@@ -217,4 +220,4 @@ Meta.test("prisma migrations", async (t) => {
       .expectData({ findManyRecords: [] })
       .on(e);
   });
-}, { systemTypegraphs: true });
+});

--- a/typegate/tests/runtimes/deno/deno_test.ts
+++ b/typegate/tests/runtimes/deno/deno_test.ts
@@ -226,7 +226,10 @@ Meta.test("Deno runtime: script reloading", async (t) => {
   await testReload(2);
 });
 
-Meta.test("Deno runtime: infinite loop or similar", async (t) => {
+Meta.test({
+  name: "Deno runtime: infinite loop or similar",
+  sanitizeOps: false,
+}, async (t) => {
   const e = await t.engine("runtimes/deno/deno.py");
 
   await t.should("safely fail upon stack overflow", async () => {
@@ -255,4 +258,4 @@ Meta.test("Deno runtime: infinite loop or similar", async (t) => {
   const cooldownTime = 5;
   console.log(`cooldown ${cooldownTime}s`);
   await sleep(cooldownTime * 1000);
-}, { sanitizeOps: false });
+});

--- a/typegate/tests/runtimes/python_wasi/python_wasi_test.ts
+++ b/typegate/tests/runtimes/python_wasi/python_wasi_test.ts
@@ -212,7 +212,10 @@ Meta.test("Deno: def, lambda, import", async (t) => {
   });
 });
 
-Meta.test("Python WASI: infinite loop or similar", async (t) => {
+Meta.test({
+  name: "Python WASI: infinite loop or similar",
+  sanitizeOps: false,
+}, async (t) => {
   const e = await t.engine("runtimes/python_wasi/python_wasi.py");
 
   await t.should("safely fail upon stackoverflow", async () => {
@@ -241,7 +244,7 @@ Meta.test("Python WASI: infinite loop or similar", async (t) => {
   //     .expectErrorContains("timeout exceeded")
   //     .on(e);
   // });
-}, { sanitizeOps: false });
+});
 
 Meta.test("Python WASI: typegate reloading", async (metaTest) => {
   const load = async () => {

--- a/typegate/tests/runtimes/temporal/temporal_test.ts
+++ b/typegate/tests/runtimes/temporal/temporal_test.ts
@@ -31,10 +31,12 @@ async function waitForHealthy(
   throw Error("stderr lost before healthy");
 }
 
-Meta.test("Typegraph using temporal", async (t) => {
+Meta.test({
+  name: "Typegraph using temporal",
+}, async (t) => {
   await testSerialize(t, "runtimes/temporal/temporal.py");
   await testSerialize(t, "runtimes/temporal/temporal.ts");
-}, {});
+});
 
 Meta.test("temporal integ", async (t) => {
   const greenFlag = [];

--- a/typegate/tests/runtimes/typegate/typegate_prisma_test.ts
+++ b/typegate/tests/runtimes/typegate/typegate_prisma_test.ts
@@ -8,7 +8,10 @@ const adminHeaders = {
   "Authorization": `Basic ${btoa("admin:password")}`,
 };
 
-Meta.test("typegate: find available operations", async (t) => {
+Meta.test({
+  name: "typegate: find available operations",
+  systemTypegraphs: true,
+}, async (t) => {
   const prismaEngine = await t.engine("runtimes/prisma/prisma.py", {
     secrets: {
       POSTGRES:
@@ -95,6 +98,4 @@ Meta.test("typegate: find available operations", async (t) => {
       })
       .on(e);
   });
-}, {
-  systemTypegraphs: true,
 });

--- a/typegate/tests/runtimes/typegate/typegate_runtime_test.ts
+++ b/typegate/tests/runtimes/typegate/typegate_runtime_test.ts
@@ -4,7 +4,10 @@
 import { dropSchemas, recreateMigrations } from "../../utils/migrations.ts";
 import { gql, Meta } from "../../utils/mod.ts";
 
-Meta.test("typegate: find available operations", async (t) => {
+Meta.test({
+  name: "typegate: find available operations",
+  systemTypegraphs: true,
+}, async (t) => {
   const prismaEngine = await t.engine("runtimes/prisma/prisma.py", {
     secrets: {
       POSTGRES:
@@ -68,6 +71,4 @@ Meta.test("typegate: find available operations", async (t) => {
       .matchSnapshot(t)
       .on(e);
   });
-}, {
-  systemTypegraphs: true,
 });

--- a/typegate/tests/runtimes/wasmedge/wasmedge_test.ts
+++ b/typegate/tests/runtimes/wasmedge/wasmedge_test.ts
@@ -26,7 +26,11 @@ const auth = new BasicAuth("admin", "password");
 //   });
 // }, { port: port });
 
-Meta.test("WasmEdge Runtime typescript sdk", async (metaTest) => {
+Meta.test({
+  name: "WasmEdge Runtime typescript sdk",
+  port: true,
+  systemTypegraphs: true,
+}, async (metaTest) => {
   const port = metaTest.port;
   const gate = `http://localhost:${port}`;
 
@@ -60,4 +64,4 @@ Meta.test("WasmEdge Runtime typescript sdk", async (metaTest) => {
       .on(engine);
     await engine.terminate();
   });
-}, { port: true, systemTypegraphs: true });
+});

--- a/typegate/tests/simple/class_syntax_test.ts
+++ b/typegate/tests/simple/class_syntax_test.ts
@@ -3,7 +3,10 @@
 
 import { gql, Meta } from "../utils/mod.ts";
 
-Meta.test("Class Syntax", async (t) => {
+Meta.test({
+  name: "Class Syntax",
+  introspection: true,
+}, async (t) => {
   const e = await t.engine("simple/class_syntax.py");
   await t.should("work using the class syntax", async () => {
     await gql`
@@ -148,4 +151,4 @@ Meta.test("Class Syntax", async (t) => {
       .matchOkSnapshot(t)
       .on(e);
   });
-}, { introspection: true });
+});

--- a/typegate/tests/type_nodes/array_of_optional_test.ts
+++ b/typegate/tests/type_nodes/array_of_optional_test.ts
@@ -3,7 +3,10 @@
 
 import { gql, Meta } from "../utils/mod.ts";
 
-Meta.test("array of optional", async (t) => {
+Meta.test({
+  name: "array of optional",
+  introspection: true,
+}, async (t) => {
   const e = await t.engine("type_nodes/array_of_optional.py");
   await t.should("work with array of optional scalars", async () => {
     await gql`
@@ -81,4 +84,4 @@ Meta.test("array of optional", async (t) => {
     `.matchErrorSnapshot(t)
       .on(e);
   });
-}, { introspection: true });
+});

--- a/typegate/tests/type_nodes/either_test.ts
+++ b/typegate/tests/type_nodes/either_test.ts
@@ -3,17 +3,90 @@
 
 import { gql, Meta } from "../utils/mod.ts";
 
-Meta.test(
-  "Either type",
-  async (t) => {
-    const e = await t.engine("type_nodes/either_node.py");
+Meta.test({
+  name: "Either type",
+  introspection: true,
+}, async (t) => {
+  const e = await t.engine("type_nodes/either_node.py");
 
-    await t.should("allow query with kid variant", async () => {
+  await t.should("allow query with kid variant", async () => {
+    await gql`
+      query {
+        regist_user(user: { age: 11, name: "Bob", school: "The school" }) {
+          ... on SuccessTransaction {
+            user_id
+            date
+          }
+          ... on FailedTransaction {
+            reason
+          }
+        }
+      }
+    `
+      .expectData({
+        regist_user: {
+          user_id: "Bob",
+          date: "2023-01-01",
+        },
+      })
+      .on(e);
+  });
+
+  await t.should("allow query with teen variant", async () => {
+    await gql`
+      query {
+        regist_user(user: { age: 20, name: "Dave", college: "The college" }) {
+          ... on SuccessTransaction {
+            user_id
+            date
+          }
+          ... on FailedTransaction {
+            reason
+          }
+        }
+      }
+    `
+      .expectData({
+        regist_user: {
+          user_id: "Dave",
+          date: "2023-01-01",
+        },
+      })
+      .on(e);
+  });
+
+  await t.should("allow query with adult variant", async () => {
+    await gql`
+      query {
+        regist_user(user: { age: 32, name: "John", company: "The company" }) {
+          ... on SuccessTransaction {
+            user_id
+            date
+          }
+          ... on FailedTransaction {
+            reason
+          }
+        }
+      }
+    `
+      .expectData({
+        regist_user: {
+          user_id: "John",
+          date: "2023-01-01",
+        },
+      })
+      .on(e);
+  });
+
+  await t.should(
+    "return only the selected fields when the returned value is an object",
+    async () => {
       await gql`
         query {
-          regist_user(user: { age: 11, name: "Bob", school: "The school" }) {
+          regist_user(
+            user: { age: 32, name: "John", company: "The company" }
+          ) {
             ... on SuccessTransaction {
-              user_id
               date
             }
             ... on FailedTransaction {
@@ -24,17 +97,27 @@ Meta.test(
       `
         .expectData({
           regist_user: {
-            user_id: "Bob",
             date: "2023-01-01",
           },
         })
         .on(e);
-    });
+    },
+  );
 
-    await t.should("allow query with teen variant", async () => {
+  await t.should(
+    "fail to query if the value does not match a variant type",
+    async () => {
       await gql`
         query {
-          regist_user(user: { age: 20, name: "Dave", college: "The college" }) {
+          regist_user(
+            user: {
+              age: 5
+              name: "John"
+              # a kid of 5 years should not have company field as it is
+              # reserved for adult variant type
+              company: "The company"
+            }
+          ) {
             ... on SuccessTransaction {
               user_id
               date
@@ -45,19 +128,23 @@ Meta.test(
           }
         }
       `
-        .expectData({
-          regist_user: {
-            user_id: "Dave",
-            date: "2023-01-01",
-          },
-        })
+        .matchErrorSnapshot(t)
         .on(e);
-    });
+    },
+  );
 
-    await t.should("allow query with adult variant", async () => {
+  await t.should(
+    "fail to query if a value is missing for the variant type it matches",
+    async () => {
       await gql`
         query {
-          regist_user(user: { age: 32, name: "John", company: "The company" }) {
+          regist_user(
+            user: {
+              # missing 'name' field
+              age: 5
+              school: "The school"
+            }
+          ) {
             ... on SuccessTransaction {
               user_id
               date
@@ -68,115 +155,27 @@ Meta.test(
           }
         }
       `
-        .expectData({
-          regist_user: {
-            user_id: "John",
-            date: "2023-01-01",
-          },
-        })
+        .expectErrorContains("Type mismatch: got 'ObjectValue'")
         .on(e);
-    });
+    },
+  );
 
-    await t.should(
-      "return only the selected fields when the returned value is an object",
-      async () => {
-        await gql`
-          query {
-            regist_user(
-              user: { age: 32, name: "John", company: "The company" }
-            ) {
-              ... on SuccessTransaction {
-                date
-              }
-              ... on FailedTransaction {
-                reason
-              }
-            }
-          }
-        `
-          .expectData({
-            regist_user: {
-              date: "2023-01-01",
-            },
-          })
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "fail to query if the value does not match a variant type",
-      async () => {
-        await gql`
-          query {
-            regist_user(
-              user: {
-                age: 5
-                name: "John"
-                # a kid of 5 years should not have company field as it is
-                # reserved for adult variant type
-                company: "The company"
-              }
-            ) {
-              ... on SuccessTransaction {
-                user_id
-                date
-              }
-              ... on FailedTransaction {
-                reason
-              }
-            }
-          }
-        `
-          .matchErrorSnapshot(t)
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "fail to query if a value is missing for the variant type it matches",
-      async () => {
-        await gql`
-          query {
-            regist_user(
-              user: {
-                # missing 'name' field
-                age: 5
-                school: "The school"
-              }
-            ) {
-              ... on SuccessTransaction {
-                user_id
-                date
-              }
-              ... on FailedTransaction {
-                reason
-              }
-            }
-          }
-        `
-          .expectErrorContains("Type mismatch: got 'ObjectValue'")
-          .on(e);
-      },
-    );
-
-    await t.should("allow to introspect the either type", async () => {
-      await gql`
-        query IntrospectionQuery {
-          __schema {
-            types {
+  await t.should("allow to introspect the either type", async () => {
+    await gql`
+      query IntrospectionQuery {
+        __schema {
+          types {
+            name
+            kind
+            possibleTypes {
               name
               kind
-              possibleTypes {
-                name
-                kind
-              }
             }
           }
         }
-      `
-        .matchOkSnapshot(t)
-        .on(e);
-    });
-  },
-  { introspection: true },
-);
+      }
+    `
+      .matchOkSnapshot(t)
+      .on(e);
+  });
+});

--- a/typegate/tests/type_nodes/union_node_attr_test.ts
+++ b/typegate/tests/type_nodes/union_node_attr_test.ts
@@ -3,95 +3,94 @@
 
 import { gql, Meta } from "../utils/mod.ts";
 
-Meta.test(
-  "Union type",
-  async (t) => {
-    const e = await t.engine("type_nodes/union_node_attr.py");
+Meta.test({
+  name: "Union type",
+  introspection: true,
+}, async (t) => {
+  const e = await t.engine("type_nodes/union_node_attr.py");
 
-    await t.should("be normalized and represented as rgb color", async () => {
-      await gql`
-        query {
-          normalize(x: 8, y: 0, z: 6, as: "color") {
-            ... on Rgb { R G B }
-            ... on Vec { x y z }
-            ... on AxisPair {
-              xy { first second }
-              xz { first second }
-              yz { first second }
-            }
+  await t.should("be normalized and represented as rgb color", async () => {
+    await gql`
+      query {
+        normalize(x: 8, y: 0, z: 6, as: "color") {
+          ... on Rgb { R G B }
+          ... on Vec { x y z }
+          ... on AxisPair {
+            xy { first second }
+            xz { first second }
+            yz { first second }
           }
         }
-      `
-        .expectData({
-          normalize: { R: 0.8, G: 0, B: 0.6 },
-        })
-        .on(e);
-    });
+      }
+    `
+      .expectData({
+        normalize: { R: 0.8, G: 0, B: 0.6 },
+      })
+      .on(e);
+  });
 
-    await t.should("be normalized and represented as vec", async () => {
+  await t.should("be normalized and represented as vec", async () => {
+    await gql`
+      query {
+        normalize(x: 8, y: 0, z: 6, as: "vec") {
+          ... on Rgb { R G B }
+          ... on Vec { x y z }
+          ... on AxisPair {
+            xy { first second }
+            xz { first second }
+            yz { first second }
+          }
+        }
+      }
+    `
+      .expectData({
+        normalize: { x: 0.8, y: 0, z: 0.6 },
+      })
+      .on(e);
+  });
+
+  await t.should(
+    "be normalized and return the x component only",
+    async () => {
       await gql`
         query {
           normalize(x: 8, y: 0, z: 6, as: "vec") {
-            ... on Rgb { R G B }
-            ... on Vec { x y z }
-            ... on AxisPair {
-              xy { first second }
-              xz { first second }
-              yz { first second }
-            }
-          }
-        }
-      `
-        .expectData({
-          normalize: { x: 0.8, y: 0, z: 0.6 },
-        })
-        .on(e);
-    });
-
-    await t.should(
-      "be normalized and return the x component only",
-      async () => {
-        await gql`
-          query {
-            normalize(x: 8, y: 0, z: 6, as: "vec") {
-              ... on Rgb { R }
-              ... on Vec { x }
-              ... on AxisPair {
-                xy { first }
-                xz { first }
-                yz { first }
-              }
-            }
-          }
-        `
-          .expectData({
-            normalize: { x: 0.8 },
-          })
-          .on(e);
-      },
-    );
-
-    await t.should("be normalized and represented as AxisPairs", async () => {
-      await gql`
-        query {
-          normalize(x: 8, y: 0, z: 6, as: "pair") {
-            ... on Rgb { R G B }
-            ... on Vec { x y z }
+            ... on Rgb { R }
+            ... on Vec { x }
             ... on AxisPair {
               xy { first }
-              xz { first second }
+              xz { first }
+              yz { first }
             }
           }
         }
       `
         .expectData({
-          normalize: {
-            xz: { first: 0.8, second: 0.6 },
-            xy: { first: 0.8 },
-          },
+          normalize: { x: 0.8 },
         })
         .on(e);
-    });
-  },
-  { introspection: true },
-);
+    },
+  );
+
+  await t.should("be normalized and represented as AxisPairs", async () => {
+    await gql`
+      query {
+        normalize(x: 8, y: 0, z: 6, as: "pair") {
+          ... on Rgb { R G B }
+          ... on Vec { x y z }
+          ... on AxisPair {
+            xy { first }
+            xz { first second }
+          }
+        }
+      }
+    `
+      .expectData({
+        normalize: {
+          xz: { first: 0.8, second: 0.6 },
+          xy: { first: 0.8 },
+        },
+      })
+      .on(e);
+  });
+});

--- a/typegate/tests/type_nodes/union_node_quantifier_test.ts
+++ b/typegate/tests/type_nodes/union_node_quantifier_test.ts
@@ -3,102 +3,101 @@
 
 import { gql, Meta } from "../utils/mod.ts";
 
-Meta.test(
-  "Union type",
-  async (t) => {
-    const e = await t.engine("type_nodes/union_node_quantifier.py");
+Meta.test({
+  name: "Union type",
+  introspection: true,
+}, async (t) => {
+  const e = await t.engine("type_nodes/union_node_quantifier.py");
 
-    await t.should("work with optionals and list arguments", async () => {
-      await gql`
-          query {
-            registerPhone(
-              phone: {
-                name: "LG",
-                battery: 5000,
-                metadatas: [
-                  {label: "IMEI", content: "1234567891011", source: "Factory1234"},
-                  {label: "ref", content: "LG_1234"},
-                ]
-              }
-            ) {
-              message
-              type
-              phone {
-                ... on BasicPhone {
-                  name
-                  metadatas {
-                    label
-                    content
-                    source
-                  }
-                }
-                ... on SmartPhone {
-                  name
-                  metadatas {
-                    label
-                    content
-                    source
-                  }
-                }
-              }
-            }
-          }
-        `
-        .expectData({
-          registerPhone: {
-            message: "LG registered",
-            type: "Basic",
-            phone: {
-              name: "LG",
-              metadatas: [
-                {
-                  label: "IMEI",
-                  content: "1234567891011",
-                  source: "Factory1234",
-                },
-                {
-                  label: "ref",
-                  content: "LG_1234",
-                },
-              ],
-            },
-          },
-        })
-        .on(e);
-    });
-
-    await t.should("work with optional field completed", async () => {
-      await gql`
+  await t.should("work with optionals and list arguments", async () => {
+    await gql`
         query {
           registerPhone(
             phone: {
-              name: "SAMSUNG",
-              camera: 50,
+              name: "LG",
               battery: 5000,
-              os: "Android"
+              metadatas: [
+                {label: "IMEI", content: "1234567891011", source: "Factory1234"},
+                {label: "ref", content: "LG_1234"},
+              ]
             }
           ) {
             message
             type
             phone {
-              ... on SmartPhone { name os }
-              ... on BasicPhone { name os }
+              ... on BasicPhone {
+                name
+                metadatas {
+                  label
+                  content
+                  source
+                }
+              }
+              ... on SmartPhone {
+                name
+                metadatas {
+                  label
+                  content
+                  source
+                }
+              }
             }
           }
         }
       `
-        .expectData({
-          registerPhone: {
-            message: "SAMSUNG registered",
-            type: "Smartphone",
-            phone: {
-              name: "SAMSUNG",
-              os: "Android",
-            },
+      .expectData({
+        registerPhone: {
+          message: "LG registered",
+          type: "Basic",
+          phone: {
+            name: "LG",
+            metadatas: [
+              {
+                label: "IMEI",
+                content: "1234567891011",
+                source: "Factory1234",
+              },
+              {
+                label: "ref",
+                content: "LG_1234",
+              },
+            ],
           },
-        })
-        .on(e);
-    });
-  },
-  { introspection: true },
-);
+        },
+      })
+      .on(e);
+  });
+
+  await t.should("work with optional field completed", async () => {
+    await gql`
+      query {
+        registerPhone(
+          phone: {
+            name: "SAMSUNG",
+            camera: 50,
+            battery: 5000,
+            os: "Android"
+          }
+        ) {
+          message
+          type
+          phone {
+            ... on SmartPhone { name os }
+            ... on BasicPhone { name os }
+          }
+        }
+      }
+    `
+      .expectData({
+        registerPhone: {
+          message: "SAMSUNG registered",
+          type: "Smartphone",
+          phone: {
+            name: "SAMSUNG",
+            os: "Android",
+          },
+        },
+      })
+      .on(e);
+  });
+});

--- a/typegate/tests/type_nodes/union_test.ts
+++ b/typegate/tests/type_nodes/union_test.ts
@@ -4,173 +4,172 @@
 import { JSONValue } from "../../src/utils.ts";
 import { gql, Meta } from "../utils/mod.ts";
 
-Meta.test(
-  "Union type",
-  async (t) => {
-    const e = await t.engine("type_nodes/union_node.py");
+Meta.test({
+  name: "Union type",
+  introspection: true,
+}, async (t) => {
+  const e = await t.engine("type_nodes/union_node.py");
 
-    await t.should(
-      "allow query with variant colorName of type string in union value Color",
-      async () => {
-        await gql`
-          query {
-            convert(color: { name: "blue" }, to: "rgb_array") {
-              ... on RGBArray { rgb }
-              ... on RGBStruct { r g b }
-              ... on HexColor { hex }
-              ... on NamedColor { name }
-            }
-          }
-        `
-          .expectData({
-            convert: { rgb: [0, 0, 255] },
-          })
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "allow query with variant HEX of type string in union value Color",
-      async () => {
-        await gql`
-          query {
-            convert(color: { hex: "#ffffff" }, to: "rgb_array") {
-              ... on RGBArray { rgb }
-              ... on RGBStruct { r g b }
-              ... on HexColor { hex }
-              ... on NamedColor { name }
-            }
-          }
-        `
-          .expectData({
-            convert: { rgb: [255, 255, 255] },
-          })
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "allow query with variant RGB of type array in union value Color",
-      async () => {
-        await gql`
-          query {
-            convert(color: { rgb: [220, 20, 60] }, to: "hex") {
-              ... on RGBArray { rgb }
-              ... on RGBStruct { r g b }
-              ... on HexColor { hex }
-              ... on NamedColor { name }
-            }
-          }
-        `
-          .expectData({
-            convert: { hex: "#dc143c" },
-          })
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "allow query with variant RGB of type struct in union value Color",
-      async () => {
-        await gql`
-          query {
-            convert(color: { r: 155, g: 38, b: 182 }, to: "rgb_struct") {
-              ... on RGBArray { rgb }
-              ... on RGBStruct { r g b }
-              ... on HexColor { hex }
-              ... on NamedColor { name }
-            }
-          }
-        `
-          .expectData({
-            convert: {
-              r: 155,
-              g: 38,
-              b: 182,
-            },
-          })
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "return only the selected fields when the returned value is an object",
-      async () => {
-        await gql`
-          query {
-            convert(color: { r: 155, g: 38, b: 182 }, to: "rgb_struct") {
-              ... on RGBArray { rgb }
-              ... on RGBStruct { r }
-              ... on HexColor { hex }
-              ... on NamedColor { name }
-            }
-          }
-        `
-          .expectData({
-            convert: {
-              r: 155,
-            },
-          })
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "fail to query with a type not present in union type Color",
-      async () => {
-        await gql`
-          query {
-            convert(color: 100, to: "rgb_array") {
-              ... on RGBArray { rgb }
-              ... on RGBStruct { r g b }
-              ... on HexColor { hex }
-              ... on NamedColor { name }
-            }
-          }
-        `
-          .expectErrorContains("Type mismatch: got 'IntValue'")
-          .on(e);
-      },
-    );
-
-    await t.should(
-      "fail to query if the value does not match a variant type",
-      async () => {
-        await gql`
-          query {
-            convert(color: "hello world", to: "rgb_array") {
-              ... on RGBArray { rgb }
-              ... on RGBStruct { r g b }
-              ... on HexColor { hex }
-              ... on NamedColor { name }
-            }
-          }
-        `
-          .matchErrorSnapshot(t)
-          .on(e);
-      },
-    );
-    await t.should("allow to introspect the union type", async () => {
+  await t.should(
+    "allow query with variant colorName of type string in union value Color",
+    async () => {
       await gql`
-        query IntrospectionQuery {
-          __schema {
-            types {
-              name
-              kind
-              possibleTypes {
-                name
-                kind
-              }
-            }
+        query {
+          convert(color: { name: "blue" }, to: "rgb_array") {
+            ... on RGBArray { rgb }
+            ... on RGBStruct { r g b }
+            ... on HexColor { hex }
+            ... on NamedColor { name }
           }
         }
       `
-        .matchOkSnapshot(t)
+        .expectData({
+          convert: { rgb: [0, 0, 255] },
+        })
         .on(e);
-    });
-  },
-  { introspection: true },
-);
+    },
+  );
+
+  await t.should(
+    "allow query with variant HEX of type string in union value Color",
+    async () => {
+      await gql`
+        query {
+          convert(color: { hex: "#ffffff" }, to: "rgb_array") {
+            ... on RGBArray { rgb }
+            ... on RGBStruct { r g b }
+            ... on HexColor { hex }
+            ... on NamedColor { name }
+          }
+        }
+      `
+        .expectData({
+          convert: { rgb: [255, 255, 255] },
+        })
+        .on(e);
+    },
+  );
+
+  await t.should(
+    "allow query with variant RGB of type array in union value Color",
+    async () => {
+      await gql`
+        query {
+          convert(color: { rgb: [220, 20, 60] }, to: "hex") {
+            ... on RGBArray { rgb }
+            ... on RGBStruct { r g b }
+            ... on HexColor { hex }
+            ... on NamedColor { name }
+          }
+        }
+      `
+        .expectData({
+          convert: { hex: "#dc143c" },
+        })
+        .on(e);
+    },
+  );
+
+  await t.should(
+    "allow query with variant RGB of type struct in union value Color",
+    async () => {
+      await gql`
+        query {
+          convert(color: { r: 155, g: 38, b: 182 }, to: "rgb_struct") {
+            ... on RGBArray { rgb }
+            ... on RGBStruct { r g b }
+            ... on HexColor { hex }
+            ... on NamedColor { name }
+          }
+        }
+      `
+        .expectData({
+          convert: {
+            r: 155,
+            g: 38,
+            b: 182,
+          },
+        })
+        .on(e);
+    },
+  );
+
+  await t.should(
+    "return only the selected fields when the returned value is an object",
+    async () => {
+      await gql`
+        query {
+          convert(color: { r: 155, g: 38, b: 182 }, to: "rgb_struct") {
+            ... on RGBArray { rgb }
+            ... on RGBStruct { r }
+            ... on HexColor { hex }
+            ... on NamedColor { name }
+          }
+        }
+      `
+        .expectData({
+          convert: {
+            r: 155,
+          },
+        })
+        .on(e);
+    },
+  );
+
+  await t.should(
+    "fail to query with a type not present in union type Color",
+    async () => {
+      await gql`
+        query {
+          convert(color: 100, to: "rgb_array") {
+            ... on RGBArray { rgb }
+            ... on RGBStruct { r g b }
+            ... on HexColor { hex }
+            ... on NamedColor { name }
+          }
+        }
+      `
+        .expectErrorContains("Type mismatch: got 'IntValue'")
+        .on(e);
+    },
+  );
+
+  await t.should(
+    "fail to query if the value does not match a variant type",
+    async () => {
+      await gql`
+        query {
+          convert(color: "hello world", to: "rgb_array") {
+            ... on RGBArray { rgb }
+            ... on RGBStruct { r g b }
+            ... on HexColor { hex }
+            ... on NamedColor { name }
+          }
+        }
+      `
+        .matchErrorSnapshot(t)
+        .on(e);
+    },
+  );
+  await t.should("allow to introspect the union type", async () => {
+    await gql`
+      query IntrospectionQuery {
+        __schema {
+          types {
+            name
+            kind
+            possibleTypes {
+              name
+              kind
+            }
+          }
+        }
+      }
+    `
+      .matchOkSnapshot(t)
+      .on(e);
+  });
+});
 
 Meta.test("nested unions", async (t) => {
   const e = await t.engine("type_nodes/union_node.py");

--- a/typegate/tests/utils/autotest.ts
+++ b/typegate/tests/utils/autotest.ts
@@ -72,7 +72,7 @@ export async function autoTest(rootDir: string, target = "dev") {
     const config = yaml.parse(await Deno.readTextFile(configFile)) as any;
     const secrets = config.typegates[target]?.env ?? {};
 
-    test(`Auto-tests for ${name}`, async (t) => {
+    test({ name: `Auto-tests for ${name}`, introspection: true }, async (t) => {
       const e = await t.engine(pythonFile.path, {
         secrets,
         autoSecretName: false,
@@ -113,6 +113,6 @@ export async function autoTest(rootDir: string, target = "dev") {
             .on(e);
         },
       );
-    }, { introspection: true });
+    });
   }
 }

--- a/typegate/tests/utils/test.ts
+++ b/typegate/tests/utils/test.ts
@@ -273,9 +273,8 @@ interface TestConfig {
 
 interface Test {
   (
-    name: string,
+    opts: string | Omit<Deno.TestDefinition, "fn"> & TestConfig,
     fn: (t: MetaTest) => void | Promise<void>,
-    opts?: Omit<Deno.TestDefinition, "name" | "fn"> & TestConfig,
   ): void;
 }
 
@@ -284,9 +283,9 @@ interface TestExt extends Test {
   ignore: Test;
 }
 
-export const test = ((name, fn, opts = {}): void => {
+export const test = ((o, fn): void => {
+  const opts = typeof o === "string" ? { name: o } : o;
   return Deno.test({
-    name,
     async fn(t) {
       if (opts.setup != null) {
         await opts.setup();
@@ -349,7 +348,8 @@ export const test = ((name, fn, opts = {}): void => {
   });
 }) as TestExt;
 
-test.only = (name, fn, opts = {}) => test(name, fn, { ...opts, only: true });
+test.only = (o, fn) =>
+  test({ ...(typeof o === "string" ? { name: o } : o), only: true }, fn);
 
-test.ignore = (name, fn, opts = {}) =>
-  test(name, fn, { ...opts, ignore: true });
+test.ignore = (o, fn) =>
+  test({ ...(typeof o === "string" ? { name: o } : o), ignore: true }, fn);

--- a/whiz.yaml
+++ b/whiz.yaml
@@ -51,6 +51,7 @@ typegraph:
     WASM_FILE: target/debug/typegraph_core.wasm
   command: |
     set -e
+    set -x
     cargo build -p typegraph_core --target wasm32-unknown-unknown --target-dir target/wasm
     wasm-tools component new target/wasm/wasm32-unknown-unknown/debug/typegraph_core.wasm -o $WASM_FILE
 


### PR DESCRIPTION
Pass the test options in the first parameter along with the test name/description.

#### Motivation and context

Avoid scrolling to the end of the test function to see/update the test options.

#### Migration notes

_N/A_

### Checklist

- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
