### PR TITLE
fix: Do not override log level when no verbosity flag is present

### DIFF
--- a/meta-cli/src/main.rs
+++ b/meta-cli/src/main.rs
@@ -53,7 +53,9 @@ fn main() -> Result<()> {
         Err(e) => e.exit(),
     };
 
-    log::set_max_level(args.verbose.log_level_filter());
+    if args.verbose.is_present() {
+        log::set_max_level(args.verbose.log_level_filter());
+    }
 
     if args.version {
         println!("meta {}", build::PKG_VERSION);


### PR DESCRIPTION
<!--
Pull requests are squash merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog.
-->

<!-- 1. Explain below WHAT the change is -->

Remove log level override by the verbosity flag when no flag is present.
It will default to the configured env_logger default level (or env variable).

<!-- 2. Explain below WHY the change cannot be made simpler -->

...

<!-- 3. Explain below WHY the was made or link an issue number -->

The default log level became "error" after #664, and `RUST_LOG` environment variable where ignored.

<!-- 4. Explain HOW users should update their code or remove that section -->

#### Migration notes

_N/A_

<!-- 5. Readiness checklist
- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
-->
