### PR TITLE
chore(sdk,gate): bump wasmtime to 20.0.0 and wit-bindgen to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.32.2",
  "rustc-demangle",
 ]
 
@@ -1816,18 +1816,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b57d4f3ffc28bbd6ef1ca7b50b20126717232f97487efe027d135d9d87eb29c"
+checksum = "79b27922a6879b5b5361d0a084cb0b1941bf109a98540addcb932da13b68bed4"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f7d0ac7fd53f2c29db3ff9a063f6ff5a8be2abaa8f6942aceb6e1521e70df7"
+checksum = "304c455b28bf56372729acb356afbb55d622f2b0f2f7837aa5e57c138acaac4d"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1846,33 +1846,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40bf21460a600178956cb7fd900a7408c6587fbb988a8063f7215361801a1da"
+checksum = "1653c56b99591d07f67c5ca7f9f25888948af3f4b97186bff838d687d666f613"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d792ecc1243b7ebec4a7f77d9ed428ef27456eeb1f8c780587a6f5c38841be19"
+checksum = "f5b6a9cf6b6eb820ee3f973a0db313c05dc12d370f37b4fe9630286e1672573f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea2808043df964b73ad7582e09afbbe06a31f3fb9db834d53e74b4e16facaeb"
+checksum = "d9d06e6bf30075fb6bed9e034ec046475093392eea1aff90eb5c44c4a033d19a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1930946836da6f514da87625cd1a0331f3908e0de454628c24a0b97b130c4d4"
+checksum = "29be04f931b73cdb9694874a295027471817f26f26d2f0ebe5454153176b6e3a"
 dependencies = [
  "serde 1.0.198",
  "serde_derive",
@@ -1880,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5482a5fcdf98f2f31b21093643bdcfe9030866b8be6481117022e7f52baa0f2b"
+checksum = "a07fd7393041d7faa2f37426f5dc7fc04003b70988810e8c063beefeff1cd8f9"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1892,15 +1892,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6e1869b6053383bdb356900e42e33555b4c9ebee05699469b7c53cdafc82ea"
+checksum = "f341d7938caa6dff8149dac05bb2b53fc680323826b83b4cf175ab9f5139a3c9"
 
 [[package]]
 name = "cranelift-native"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91446e8045f1c4bc164b7bba68e2419c623904580d4b730877a663c6da38964"
+checksum = "82af6066e6448d26eeabb7aa26a43f7ff79f8217b06bade4ee6ef230aecc8880"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1909,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.106.2"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b17979b862d3b0d52de6ae3294ffe4d86c36027b56ad0443a7c8c8f921d14f"
+checksum = "2766fab7284a914a7f17f90ebe865c86453225fb8637ac31f123f5028fee69cd"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1919,7 +1919,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser 0.201.0",
+ "wasmparser 0.202.0",
  "wasmtime-types",
 ]
 
@@ -6193,6 +6193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7204,6 +7213,15 @@ name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.3",
@@ -12553,6 +12571,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd106365a7f5f7aa3c1916a98cbb3ad477f5ff96ddb130285a91c6e7429e67a"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.205.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e95b3563d164f33c1cfb0a7efbd5940c37710019be10cd09f800fdec8b0e5c"
@@ -12702,20 +12729,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.201.0"
+name = "wasmparser"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67e66da702706ba08729a78e3c0079085f6bfcb1a62e4799e97bbf728c2c265"
+checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
+dependencies = [
+ "bitflags 2.5.0",
+ "indexmap 2.2.6",
+ "semver 1.0.22",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1cc9508685eef9502e787f4d4123745f5651a1e29aec047645d3cac1e2da7a"
 dependencies = [
  "anyhow",
- "wasmparser 0.201.0",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e300c0e3f19dc9064e3b17ce661088646c70dbdde36aab46470ed68ba58db7d"
+checksum = "5a5990663c28d81015ddbb02a068ac1bf396a4ea296eba7125b2dfc7c00cb52e"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -12730,7 +12768,7 @@ dependencies = [
  "ittapi",
  "libc",
  "log",
- "object",
+ "object 0.33.0",
  "once_cell",
  "paste",
  "rayon",
@@ -12740,8 +12778,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "target-lexicon",
- "wasm-encoder 0.201.0",
- "wasmparser 0.201.0",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -12759,18 +12797,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110aa598e02a136fb095ca70fa96367fc16bab55256a131e66f9b58f16c73daf"
+checksum = "625ee94c72004f3ea0228989c9506596e469517d7d0ed66f7300d1067bdf1ca9"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e660537b0ac2fc76917fb0cc9d403d2448b6983a84e59c51f7fea7b7dae024"
+checksum = "98534bf28de232299e83eab33984a7a6c40c69534d6bd0ea216150b63d41a83a"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -12788,9 +12826,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091f32ce586251ac4d07019388fb665b010d9518ffe47be1ddbabb162eed6007"
+checksum = "64f84414a25ee3a624c8b77550f3fe7b5d8145bd3405ca58886ee6900abb6dc2"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -12798,20 +12836,20 @@ dependencies = [
  "syn 2.0.60",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.201.0",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd17dc1ebc0b28fd24b6b9d07638f55b82ae908918ff08fd221f8b0fefa9125"
+checksum = "78580bdb4e04c7da3bf98088559ca1d29382668536e4d5c7f2f966d79c390307"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e923262451a4b5b39fe02f69f1338d56356db470e289ea1887346b9c7f592738"
+checksum = "b60df0ee08c6a536c765f69e9e8205273435b66d02dd401e938769a2622a6c1a"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -12823,36 +12861,19 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "log",
- "object",
+ "object 0.33.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.201.0",
- "wasmtime-cranelift-shared",
+ "wasmparser 0.202.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-cranelift-shared"
-version = "19.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508898cbbea0df81a5d29cfc1c7c72431a1bc4c9e89fd9514b4c868474c05c7a"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-native",
- "gimli",
- "object",
- "target-lexicon",
- "wasmtime-environ",
-]
-
-[[package]]
 name = "wasmtime-environ"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e3f2aa72dbb64c19708646e1ff97650f34e254598b82bad5578ea9c80edd30"
+checksum = "64ffc1613db69ee47c96738861534f9a405e422a5aa00224fbf5d410b03fb445"
 dependencies = [
  "anyhow",
  "bincode",
@@ -12861,14 +12882,14 @@ dependencies = [
  "gimli",
  "indexmap 2.2.6",
  "log",
- "object",
+ "object 0.33.0",
  "rustc-demangle",
  "serde 1.0.198",
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.201.0",
- "wasmparser 0.201.0",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -12876,9 +12897,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9235b643527bcbac808216ed342e1fba324c95f14a62762acfa6f2e6ca5edbd6"
+checksum = "f043514a23792761c5765f8ba61a4aa7d67f260c0c37494caabceb41d8ae81de"
 dependencies = [
  "anyhow",
  "cc",
@@ -12891,11 +12912,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92de34217bf7f0464262adf391a9950eba440f9dfc7d3b0e3209302875c6f65f"
+checksum = "9c0ca2ad8f5d2b37f507ef1c935687a690e84e9f325f5a2af9639440b43c1f0e"
 dependencies = [
- "object",
+ "object 0.33.0",
  "once_cell",
  "rustix 0.38.34",
  "wasmtime-versioned-export-macros",
@@ -12903,9 +12924,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22ca2ef4d87b23d400660373453e274b2251bc2d674e3102497f690135e04b0"
+checksum = "7a9f93a3289057b26dc75eb84d6e60d7694f7d169c7c09597495de6e016a13ff"
 dependencies = [
  "cfg-if",
  "libc",
@@ -12914,9 +12935,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1806ee242ca4fd183309b7406e4e83ae7739b7569f395d56700de7c7ef9f5eb8"
+checksum = "c6332a2b0af4224c3ea57c857ad39acd2780ccc2b0c99ba1baa01864d90d7c94"
 dependencies = [
  "anyhow",
  "cc",
@@ -12925,47 +12946,47 @@ dependencies = [
  "indexmap 2.2.6",
  "libc",
  "log",
- "mach",
+ "mach2",
  "memfd",
  "memoffset 0.9.1",
  "paste",
  "psm",
  "rustix 0.38.34",
  "sptr",
- "wasm-encoder 0.201.0",
+ "wasm-encoder 0.202.0",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-debug",
+ "wasmtime-slab",
  "wasmtime-versioned-export-macros",
- "wasmtime-wmemcheck",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c58bef9ce877fd06acb58f08d003af17cb05cc51225b455e999fbad8e584c0"
+checksum = "8b3655075824a374c536a2b2cc9283bb765fcdf3d58b58587862c48571ad81ef"
 
 [[package]]
 name = "wasmtime-types"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cebe297aa063136d9d2e5b347c1528868aa43c2c8d0e1eb0eec144567e38fe0f"
+checksum = "b98cf64a242b0b9257604181ca28b28a5fcaa4c9ea1d396f76d1d2d1c5b40eef"
 dependencies = [
  "cranelift-entity",
  "serde 1.0.198",
  "serde_derive",
  "thiserror",
- "wasmparser 0.201.0",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffaafa5c12355b1a9ee068e9295d50c4ca0a400c721950cdae4f5b54391a2da5"
+checksum = "8561d9e2920db2a175213d557d71c2ac7695831ab472bbfafb9060cd1034684f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12974,38 +12995,32 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d618b4e90d3f259b1b77411ce573c9f74aade561957102132e169918aabdc863"
+checksum = "a06b573d14ac846a0fb8c541d8fca6a64acf9a1d176176982472274ab1d2fa5d"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli",
- "object",
+ "object 0.33.0",
  "target-lexicon",
- "wasmparser 0.201.0",
- "wasmtime-cranelift-shared",
+ "wasmparser 0.202.0",
+ "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
 ]
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "19.0.2"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7a253c8505edd7493603e548bff3af937b0b7dbf2b498bd5ff2131b651af72"
+checksum = "595bc7bb3b0ff4aa00fab718c323ea552c3034d77abc821a35112552f2ea487a"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.2.6",
- "wit-parser 0.201.0",
+ "wit-parser 0.202.0",
 ]
-
-[[package]]
-name = "wasmtime-wmemcheck"
-version = "19.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8c62e9df8322b2166d2a6f096fbec195ddb093748fd74170dcf25ef596769"
 
 [[package]]
 name = "wast"
@@ -13221,9 +13236,9 @@ dependencies = [
 
 [[package]]
 name = "winch-codegen"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15869abc9e3bb29c017c003dbe007a08e9910e8ff9023a962aa13c1b2ee6af"
+checksum = "fb23450977f9d4a23c02439cf6899340b2d68887b19465c5682740d9cc37d52e"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -13231,7 +13246,8 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.201.0",
+ "wasmparser 0.202.0",
+ "wasmtime-cranelift",
  "wasmtime-environ",
 ]
 
@@ -13625,6 +13641,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.201.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744237b488352f4f27bca05a10acb79474415951c450e52ebd0da784c1df2bcc"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver 1.0.22",
+ "serde 1.0.198",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11991,7 +11991,7 @@ dependencies = [
  "serde 1.0.198",
  "serde_json",
  "sha2 0.10.8",
- "wit-bindgen 0.12.0",
+ "wit-bindgen 0.24.0",
 ]
 
 [[package]]
@@ -12544,24 +12544,6 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34180c89672b3e4825c3a8db4b61a674f1447afd5fe2445b2d22c3d8b6ea086c"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.41.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f97a5d8318f908dded23594188a90bcd09365986b1163e66d70170e5287ae"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
@@ -12589,22 +12571,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ebaa7bd0f9e7a5e5dd29b9a998acf21c4abed74265524dd7e85934597bfb10"
-dependencies = [
- "anyhow",
- "indexmap 2.2.6",
- "serde 1.0.198",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.41.2",
- "wasmparser 0.121.2",
-]
-
-[[package]]
-name = "wasm-metadata"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fd83062c17b9f4985d438603cde0a5e8c5c8198201a6937f778b607924c7da2"
@@ -12617,6 +12583,22 @@ dependencies = [
  "spdx",
  "wasm-encoder 0.201.0",
  "wasmparser 0.201.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.202.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde 1.0.198",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
@@ -12694,27 +12676,6 @@ checksum = "2d4e7c8aebe2c513bb389beebc148253eb6f5904a6f9327179bbf2014c0efd52"
 dependencies = [
  "thiserror",
  "wat",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.113.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
-dependencies = [
- "indexmap 2.2.6",
- "semver 1.0.22",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.121.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
-dependencies = [
- "bitflags 2.5.0",
- "indexmap 2.2.6",
- "semver 1.0.22",
 ]
 
 [[package]]
@@ -13457,34 +13418,23 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f7c5d6f59ae013fc4c013c76eab667844a46e86b51987acb71b1e32953211a"
-dependencies = [
- "bitflags 2.5.0",
- "wit-bindgen-rust-macro 0.12.0",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288f992ea30e6b5c531b52cdd5f3be81c148554b09ea416f058d16556ba92c27"
 dependencies = [
  "bitflags 2.5.0",
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.22.0",
  "wit-bindgen-rust-macro 0.22.0",
 ]
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.12.0"
+name = "wit-bindgen"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0371c47784e7559efb422f74473e395b49f7101725584e2673657e0b4fc104"
+checksum = "9fb4e7653763780be47e38f479e9aa83c768aa6a3b2ed086dc2826fdbbb7e7f5"
 dependencies = [
- "anyhow",
- "wit-component 0.14.7",
- "wit-parser 0.11.3",
+ "wit-bindgen-rt 0.24.0",
+ "wit-bindgen-rust-macro 0.24.0",
 ]
 
 [[package]]
@@ -13498,23 +13448,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b67e11c950041849a10828c7600ea62a4077c01e8af72e8593253575428f91b"
+dependencies = [
+ "anyhow",
+ "wit-parser 0.202.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb8738270f32a2d6739973cbbb7c1b6dd8959ce515578a6e19165853272ee64"
 
 [[package]]
-name = "wit-bindgen-rust"
-version = "0.12.0"
+name = "wit-bindgen-rt"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeab5a09a85b1641690922ce05d79d868a2f2e78e9415a5302f58b9846fab8f1"
+checksum = "3b0780cf7046630ed70f689a098cd8d56c5c3b22f2a7379bbdb088879963ff96"
 dependencies = [
- "anyhow",
- "heck 0.4.1",
- "wasm-metadata 0.10.20",
- "wit-bindgen-core 0.12.0",
- "wit-bindgen-rust-lib",
- "wit-component 0.14.7",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -13532,28 +13487,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rust-lib"
-version = "0.12.0"
+name = "wit-bindgen-rust"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13c89c9c1a93e164318745841026f63f889376f38664f86a7f678930280e728"
-dependencies = [
- "heck 0.4.1",
- "wit-bindgen-core 0.12.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70c97e09751a9a95a592bd8ef84e953e5cdce6ebbfdb35ceefa5cc511da3b71"
+checksum = "30acbe8fb708c3a830a33c4cb705df82659bf831b492ec6ca1a17a369cfeeafb"
 dependencies = [
  "anyhow",
- "proc-macro2",
- "syn 2.0.60",
- "wit-bindgen-core 0.12.0",
- "wit-bindgen-rust 0.12.0",
- "wit-bindgen-rust-lib",
- "wit-component 0.14.7",
+ "heck 0.4.1",
+ "indexmap 2.2.6",
+ "wasm-metadata 0.202.0",
+ "wit-bindgen-core 0.24.0",
+ "wit-component 0.202.0",
 ]
 
 [[package]]
@@ -13571,21 +13515,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-component"
-version = "0.14.7"
+name = "wit-bindgen-rust-macro"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66981fe851118de3b6b7a92f51ce8a86b919569c37becbeca8df9bd30141da25"
+checksum = "2b1b06eae85feaecdf9f2854f7cac124e00d5a6e5014bfb02eb1ecdeb5f265b9"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
- "indexmap 2.2.6",
- "log",
- "serde 1.0.198",
- "serde_json",
- "wasm-encoder 0.33.2",
- "wasm-metadata 0.10.20",
- "wasmparser 0.113.3",
- "wit-parser 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "wit-bindgen-core 0.24.0",
+ "wit-bindgen-rust 0.24.0",
 ]
 
 [[package]]
@@ -13608,21 +13548,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-parser"
-version = "0.11.3"
+name = "wit-component"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39edca9abb16309def3843af73b58d47d243fe33a9ceee572446bcc57556b9a"
+checksum = "0c836b1fd9932de0431c1758d8be08212071b6bba0151f7bac826dbc4312a2a9"
 dependencies = [
  "anyhow",
- "id-arena",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
- "pulldown-cmark",
- "semver 1.0.22",
  "serde 1.0.198",
+ "serde_derive",
  "serde_json",
- "unicode-xid",
- "url",
+ "wasm-encoder 0.202.0",
+ "wasm-metadata 0.202.0",
+ "wasmparser 0.202.0",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]

--- a/typegate/engine/Cargo.toml
+++ b/typegate/engine/Cargo.toml
@@ -39,7 +39,7 @@ wasmedge-sdk.workspace = true
 wasmedge-sys.workspace = true
 wasmedge-types.workspace = true
 
-wasmtime = { version = "19.0.1",  features = ["component-model"] }
+wasmtime = { version = "20.0.0",  features = ["component-model"] }
 
 shadow-rs.workspace = true
 serde.workspace = true

--- a/typegraph/core/Cargo.toml
+++ b/typegraph/core/Cargo.toml
@@ -11,7 +11,7 @@ enum_dispatch = "0.3.12"
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-wit-bindgen = "0.12.0"
+wit-bindgen = "0.24.0"
 regex.workspace = true
 indexmap.workspace = true
 common = { path = "../../libs/common" }

--- a/typegraph/core/src/lib.rs
+++ b/typegraph/core/src/lib.rs
@@ -38,19 +38,12 @@ use wit::core::{
 use wit::runtimes::{Guest, MaterializerDenoFunc};
 
 pub mod wit {
-    use super::*;
-
     wit_bindgen::generate!({
-        world: "typegraph",
-        exports: {
-            "metatype:typegraph/core": Lib,
-            "metatype:typegraph/runtimes": Lib,
-            "metatype:typegraph/utils": Lib,
-            "metatype:typegraph/aws": Lib,
-        }
+        world: "typegraph"
     });
-
+    use crate::Lib;
     pub use exports::metatype::typegraph::{aws, core, runtimes, utils};
+    export!(Lib);
 }
 
 pub struct Lib {}

--- a/typegraph/core/wit/typegraph.wit
+++ b/typegraph/core/wit/typegraph.wit
@@ -1,4 +1,5 @@
-package metatype:typegraph
+package metatype:typegraph;
+
 
 interface core {
     record error {
@@ -39,7 +40,7 @@ interface core {
         size: u32,
     }
 
-    init-typegraph: func(params: typegraph-init-params) -> result<_, error>
+    init-typegraph: func(params: typegraph-init-params) -> result<_, error>;
 
     record migration-action {
         create: bool,
@@ -60,9 +61,9 @@ interface core {
         codegen: option<bool> // if set, sdk should not throw errors when the script does not exist
     }
 
-    finalize-typegraph: func(config: option<artifact-resolution-config>) -> result<tuple<string, list<artifact>>, error>
+    finalize-typegraph: func(config: option<artifact-resolution-config>) -> result<tuple<string, list<artifact>>, error>;
 
-    type type-id = u32
+    type type-id = u32;
     record type-base {
         name: option<string>,
         // string => json string
@@ -70,13 +71,13 @@ interface core {
         as-id: bool,
     }
 
-    with-injection: func(type-id: type-id, injection: string) -> result<type-id, error>
+    with-injection: func(type-id: type-id, injection: string) -> result<type-id, error>;
 
     record type-proxy {
         name: string,
         extras: list<tuple<string, string>>,
     }
-    refb: func(name: string, attributes: list<tuple<string, string>>) -> result<type-id, error>
+    refb: func(name: string, attributes: list<tuple<string, string>>) -> result<type-id, error>;
 
     record type-integer {
         min: option<s32>,
@@ -86,7 +87,7 @@ interface core {
         multiple-of: option<s32>,
         enumeration: option<list<s32>>
     }
-    integerb: func(data: type-integer, base: type-base) -> result<type-id, error>
+    integerb: func(data: type-integer, base: type-base) -> result<type-id, error>;
 
     record type-float {
         min: option<float64>,
@@ -96,9 +97,9 @@ interface core {
         multiple-of: option<float64>,
         enumeration: option<list<float64>>
     }
-    floatb: func(data: type-float, base: type-base) -> result<type-id, error>
+    floatb: func(data: type-float, base: type-base) -> result<type-id, error>;
 
-    booleanb: func(base: type-base) -> result<type-id, error>
+    booleanb: func(base: type-base) -> result<type-id, error>;
 
     record type-string {
         min: option<u32>,
@@ -107,14 +108,14 @@ interface core {
         pattern: option<string>,
         enumeration: option<list<string>>
     }
-    stringb: func(data: type-string, base: type-base) -> result<type-id, error>
+    stringb: func(data: type-string, base: type-base) -> result<type-id, error>;
 
     record type-file {
         min: option<u32>,
         max: option<u32>,
         allow: option<list<string>>,
     }
-    fileb: func(data: type-file, base: type-base) -> result<type-id, error>
+    fileb: func(data: type-file, base: type-base) -> result<type-id, error>;
 
 
     record type-list {
@@ -123,23 +124,23 @@ interface core {
         max: option<u32>,
         unique-items: option<bool>
     }
-    listb: func(data: type-list, base: type-base) -> result<type-id, error>
+    listb: func(data: type-list, base: type-base) -> result<type-id, error>;
 
     record type-optional {
         of: type-id,
         default-item: option<string>
     }
-    optionalb: func(data: type-optional, base: type-base) -> result<type-id, error>
+    optionalb: func(data: type-optional, base: type-base) -> result<type-id, error>;
 
     record type-union {
         variants: list<type-id>,
     }
-    unionb: func(data: type-union, base: type-base) -> result<type-id, error>
+    unionb: func(data: type-union, base: type-base) -> result<type-id, error>;
 
     record type-either {
         variants: list<type-id>,
     }
-    eitherb: func(data: type-either, base: type-base) -> result<type-id, error>
+    eitherb: func(data: type-either, base: type-base) -> result<type-id, error>;
 
     record type-struct {
         props: list<tuple<string, type-id>>,
@@ -148,10 +149,10 @@ interface core {
         max: option<u32>,
         enumeration: option<list<string>>,
     }
-    structb: func(data: type-struct, base: type-base) -> result<type-id, error>
-    extend-struct: func(tpe: type-id, props: list<tuple<string, type-id>>) -> result<type-id, error>
+    structb: func(data: type-struct, base: type-base) -> result<type-id, error>;
+    extend-struct: func(tpe: type-id, props: list<tuple<string, type-id>>) -> result<type-id, error>;
 
-    get-type-repr: func(id: type-id) -> result<string, error>
+    get-type-repr: func(id: type-id) -> result<string, error>;
 
     variant value-source {
         raw(string),  // json
@@ -175,16 +176,16 @@ interface core {
         rate-weight: option<u32>,
     }
 
-    funcb: func(data: type-func) -> result<type-id, error>
+    funcb: func(data: type-func) -> result<type-id, error>;
 
     record transform-data {
         query-input: type-id,
         parameter-transform: parameter-transform,
     }
 
-    get-transform-data: func(resolver-input: type-id, transform-tree: string) -> result<transform-data, error>
+    get-transform-data: func(resolver-input: type-id, transform-tree: string) -> result<transform-data, error>;
 
-    type policy-id = u32
+    type policy-id = u32;
 
     record policy {
         name: string,
@@ -203,29 +204,29 @@ interface core {
         per-effect(policy-per-effect),
     }
 
-    register-policy: func(pol: policy) -> result<policy-id, error>
+    register-policy: func(pol: policy) -> result<policy-id, error>;
 
-    with-policy: func(type-id: type-id, policy-chain: list<policy-spec>) -> result<type-id, error>
+    with-policy: func(type-id: type-id, policy-chain: list<policy-spec>) -> result<type-id, error>;
 
     // policy-id, policy-name
-    get-public-policy: func() -> result<tuple<policy-id, string>, error>
-    get-internal-policy: func() -> result<tuple<policy-id, string>, error>
+    get-public-policy: func() -> result<tuple<policy-id, string>, error>;
+    get-internal-policy: func() -> result<tuple<policy-id, string>, error>;
 
     variant context-check {
         not-null,
         value(string),
         pattern(string),
     }
-    register-context-policy: func(key: string, check: context-check) -> result<tuple<policy-id, string>, error>
+    register-context-policy: func(key: string, check: context-check) -> result<tuple<policy-id, string>, error>;
 
-    rename-type: func(tpe: type-id, new-name: string) -> result<type-id, error>
+    rename-type: func(tpe: type-id, new-name: string) -> result<type-id, error>;
 
-    expose: func(fns: list<tuple<string, type-id>>, default-policy: option<list<policy-spec>>) -> result<_, error>
+    expose: func(fns: list<tuple<string, type-id>>, default-policy: option<list<policy-spec>>) -> result<_, error>;
 
-    set-seed: func(seed: option<u32>) -> result<_, error>
+    set-seed: func(seed: option<u32>) -> result<_, error>;
     
-    type runtime-id = u32
-    type materializer-id = u32
+    type runtime-id = u32;
+    type materializer-id = u32;
 
     record func-params {
         inp: type-id,
@@ -235,11 +236,11 @@ interface core {
 }
 
 interface runtimes {
-    use core.{error, type-id, func-params, runtime-id, materializer-id, artifact}
+    use core.{error, type-id, func-params, runtime-id, materializer-id, artifact};
     
-    get-deno-runtime: func() -> runtime-id
+    get-deno-runtime: func() -> runtime-id;
 
-    type idempotency = bool
+    type idempotency = bool;
 
     variant effect {
         read,
@@ -274,11 +275,11 @@ interface runtimes {
         secrets: list<string>,
     }
 
-    register-deno-func: func(data: materializer-deno-func, effect: effect) -> result<materializer-id, error>
-    register-deno-static: func(data: materializer-deno-static, type-id: type-id) -> result<materializer-id, error>
+    register-deno-func: func(data: materializer-deno-func, effect: effect) -> result<materializer-id, error>;
+    register-deno-static: func(data: materializer-deno-static, type-id: type-id) -> result<materializer-id, error>;
 
-    get-predefined-deno-func: func(data: materializer-deno-predefined) -> result<materializer-id, error>
-    import-deno-function: func(data: materializer-deno-import, effect: effect) -> result<materializer-id, error>
+    get-predefined-deno-func: func(data: materializer-deno-predefined) -> result<materializer-id, error>;
+    import-deno-function: func(data: materializer-deno-import, effect: effect) -> result<materializer-id, error>;
 
 
     // graphql
@@ -290,9 +291,9 @@ interface runtimes {
         path: option<list<string>>,
     }
 
-    register-graphql-runtime: func(data: graphql-runtime-data) -> result<runtime-id, error>
-    graphql-query: func(base: base-materializer, data: materializer-graphql-query) -> result<materializer-id, error>
-    graphql-mutation: func(base: base-materializer, data: materializer-graphql-query) -> result<materializer-id, error>
+    register-graphql-runtime: func(data: graphql-runtime-data) -> result<runtime-id, error>;
+    graphql-query: func(base: base-materializer, data: materializer-graphql-query) -> result<materializer-id, error>;
+    graphql-mutation: func(base: base-materializer, data: materializer-graphql-query) -> result<materializer-id, error>;
 
     record http-runtime-data {
         endpoint: string,
@@ -319,8 +320,8 @@ interface runtimes {
         auth-token-field: option<string>,
     }
 
-    register-http-runtime: func(data: http-runtime-data) -> result<runtime-id, error>
-    http-request: func(base: base-materializer, data: materializer-http-request) -> result<materializer-id, error>
+    register-http-runtime: func(data: http-runtime-data) -> result<runtime-id, error>;
+    http-request: func(base: base-materializer, data: materializer-http-request) -> result<materializer-id, error>;
 
     // python
     record materializer-python-def {
@@ -346,11 +347,11 @@ interface runtimes {
         secrets: list<string>
     }
 
-    register-python-runtime: func() -> result<runtime-id, error>
-    from-python-lambda: func(base: base-materializer, data: materializer-python-lambda) -> result<materializer-id, error>
-    from-python-def: func(base: base-materializer, data: materializer-python-def) -> result<materializer-id, error>
-    from-python-module: func(base: base-materializer, data: materializer-python-module) -> result<materializer-id, error>
-    from-python-import: func(base: base-materializer, data: materializer-python-import) -> result<materializer-id, error>
+    register-python-runtime: func() -> result<runtime-id, error>;
+    from-python-lambda: func(base: base-materializer, data: materializer-python-lambda) -> result<materializer-id, error>;
+    from-python-def: func(base: base-materializer, data: materializer-python-def) -> result<materializer-id, error>;
+    from-python-module: func(base: base-materializer, data: materializer-python-module) -> result<materializer-id, error>;
+    from-python-import: func(base: base-materializer, data: materializer-python-import) -> result<materializer-id, error>;
 
     // random
     record random-runtime-data {
@@ -362,8 +363,8 @@ interface runtimes {
         runtime: runtime-id,
     }
 
-    register-random-runtime: func(data: random-runtime-data) -> result<materializer-id, error>
-    create-random-mat: func(base: base-materializer, data: materializer-random) -> result<materializer-id, error>
+    register-random-runtime: func(data: random-runtime-data) -> result<materializer-id, error>;
+    create-random-mat: func(base: base-materializer, data: materializer-random) -> result<materializer-id, error>;
 
     // wasm
     record materializer-wasm {
@@ -371,8 +372,8 @@ interface runtimes {
         wasm-artifact: string,
     }
 
-    register-wasm-runtime: func() -> result<runtime-id, error>
-    from-wasm-module: func(base: base-materializer, data: materializer-wasm) -> result<materializer-id, error>
+    register-wasm-runtime: func() -> result<runtime-id, error>;
+    from-wasm-module: func(base: base-materializer, data: materializer-wasm) -> result<materializer-id, error>;
 
     // prisma
     record prisma-runtime-data {
@@ -388,23 +389,23 @@ interface runtimes {
         unique: option<bool>,
     }
 
-    register-prisma-runtime: func(data: prisma-runtime-data) -> result<runtime-id, error>
-    prisma-find-unique: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-find-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-find-first: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-aggregate: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-count: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-group-by: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-create-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-create-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-update-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-update-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-upsert-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-delete-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-delete-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>
-    prisma-execute: func(runtime: runtime-id, query: string, param: type-id, effect: effect) -> result<func-params, error>
-    prisma-query-raw: func(runtime: runtime-id, query: string, param: option<type-id>, out: type-id) -> result<func-params, error>
-    prisma-link: func(data: prisma-link-data) -> result<type-id, error>
+    register-prisma-runtime: func(data: prisma-runtime-data) -> result<runtime-id, error>;
+    prisma-find-unique: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-find-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-find-first: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-aggregate: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-count: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-group-by: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-create-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-create-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-update-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-update-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-upsert-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-delete-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-delete-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
+    prisma-execute: func(runtime: runtime-id, query: string, param: type-id, effect: effect) -> result<func-params, error>;
+    prisma-query-raw: func(runtime: runtime-id, query: string, param: option<type-id>, out: type-id) -> result<func-params, error>;
+    prisma-link: func(data: prisma-link-data) -> result<type-id, error>;
 
 
     // prisma-migrate
@@ -415,7 +416,7 @@ interface runtimes {
         deploy,
         reset,
     }
-    prisma-migration: func(operation: prisma-migration-operation) -> result<func-params, error>
+    prisma-migration: func(operation: prisma-migration-operation) -> result<func-params, error>;
 
     // temporal
     record temporal-runtime-data {
@@ -438,8 +439,8 @@ interface runtimes {
         operation: temporal-operation-type,
     }
 
-    register-temporal-runtime: func(data: temporal-runtime-data) -> result<runtime-id, error>
-    generate-temporal-operation: func(runtime: runtime-id, data: temporal-operation-data) -> result<func-params, error>
+    register-temporal-runtime: func(data: temporal-runtime-data) -> result<runtime-id, error>;
+    generate-temporal-operation: func(runtime: runtime-id, data: temporal-operation-data) -> result<func-params, error>;
 
     // typegate
     enum typegate-operation {
@@ -458,7 +459,7 @@ interface runtimes {
         query-prisma-model,
     }
 
-    register-typegate-materializer: func(operation: typegate-operation) -> result<materializer-id, error>
+    register-typegate-materializer: func(operation: typegate-operation) -> result<materializer-id, error>;
 
     // typegraph  (introspection)
     enum typegraph-operation {
@@ -467,11 +468,11 @@ interface runtimes {
         get-schema,
     }
 
-    register-typegraph-materializer: func(operation: typegraph-operation) -> result<materializer-id, error>
+    register-typegraph-materializer: func(operation: typegraph-operation) -> result<materializer-id, error>;
 }
 
 interface aws {
-    use core.{error, runtime-id, materializer-id}
+    use core.{error, runtime-id, materializer-id};
 
     record s3-runtime-data {
         host-secret: string,
@@ -492,18 +493,18 @@ interface aws {
         content-type: option<string>,
     }
 
-    register-s3-runtime: func(data: s3-runtime-data) -> result<runtime-id, error>
-    s3-presign-get: func(runtime: runtime-id, data: s3-presign-get-params) -> result<materializer-id, error>
-    s3-presign-put: func(runtime: runtime-id, data: s3-presign-put-params) -> result<materializer-id, error>
-    s3-list: func(runtime: runtime-id, bucket: string) -> result<materializer-id, error>
-    s3-upload: func(runtime: runtime-id, bucket: string) -> result<materializer-id, error>
-    s3-upload-all: func(runtime: runtime-id, bucket: string) -> result<materializer-id, error>
+    register-s3-runtime: func(data: s3-runtime-data) -> result<runtime-id, error>;
+    s3-presign-get: func(runtime: runtime-id, data: s3-presign-get-params) -> result<materializer-id, error>;
+    s3-presign-put: func(runtime: runtime-id, data: s3-presign-put-params) -> result<materializer-id, error>;
+    s3-list: func(runtime: runtime-id, bucket: string) -> result<materializer-id, error>;
+    s3-upload: func(runtime: runtime-id, bucket: string) -> result<materializer-id, error>;
+    s3-upload-all: func(runtime: runtime-id, bucket: string) -> result<materializer-id, error>;
 }
 
 
 interface utils {
-    use core.{error}
-    type type-id = u32
+    use core.{error};
+    type type-id = u32;
 
 
     // Example:
@@ -529,9 +530,9 @@ interface utils {
         paths: list<reduce-path>
     }
 
-    gen-reduceb: func(supertype-id: type-id, data: reduce) -> result<type-id, error>
+    gen-reduceb: func(supertype-id: type-id, data: reduce) -> result<type-id, error>;
 
-    add-graphql-endpoint: func(graphql: string) -> result<u32, error>
+    add-graphql-endpoint: func(graphql: string) -> result<u32, error>;
 
     variant auth-protocol {
         oauth2,
@@ -546,43 +547,43 @@ interface utils {
         auth-data: list<tuple<string, string>>,
     }
 
-    add-auth: func(data: auth) -> result<u32, error>
-    add-raw-auth: func(data: string) -> result<u32, error>
-    oauth2: func(service-name: string, scopes: string) -> result<string, error> 
-    oauth2-without-profiler: func(service-name: string, scopes: string) -> result<string, error>
-    oauth2-with-extended-profiler: func(service-name: string, scopes: string, extension: string) -> result<string, error>
-    oauth2-with-custom-profiler: func(service-name: string, scopes: string, profiler: type-id) -> result<string, error>
+    add-auth: func(data: auth) -> result<u32, error>;
+    add-raw-auth: func(data: string) -> result<u32, error>;
+    oauth2: func(service-name: string, scopes: string) -> result<string, error>;
+    oauth2-without-profiler: func(service-name: string, scopes: string) -> result<string, error>;
+    oauth2-with-extended-profiler: func(service-name: string, scopes: string, extension: string) -> result<string, error>;
+    oauth2-with-custom-profiler: func(service-name: string, scopes: string, profiler: type-id) -> result<string, error>;
 
     record query-deploy-params {
         tg: string,
         secrets: option<list<tuple<string, string>>>,
     }
 
-    gql-deploy-query: func(params: query-deploy-params) -> result<string, error>
-    gql-remove-query: func(tg-name: list<string>) -> result<string, error>
+    gql-deploy-query: func(params: query-deploy-params) -> result<string, error>;
+    gql-remove-query: func(tg-name: list<string>) -> result<string, error>;
 
-    unpack-tarb64: func(tar-b64: string, dest: string) -> result<_, error>
+    unpack-tarb64: func(tar-b64: string, dest: string) -> result<_, error>;
 
-    remove-injections: func(type-id: type-id) -> result<type-id, error>
+    remove-injections: func(type-id: type-id) -> result<type-id, error>;
 
-    get-cwd: func() -> result<string, string>
+    get-cwd: func() -> result<string, string>;
 }
 
 interface host {
-    print: func(s: string)
-    eprint: func(s: string)
-    expand-path: func(root: string, exclude: list<string>) -> result<list<string>, string>
-    path-exists: func(path: string) -> result<bool, string>
-    read-file: func(path: string) -> result<list<u8>, string>
-    write-file: func(path: string, data: list<u8>) -> result<_, string>
-    get-cwd: func() -> result<string, string>
+    print: func(s: string);
+    eprint: func(s: string);
+    expand-path: func(root: string, exclude: list<string>) -> result<list<string>, string>;
+    path-exists: func(path: string) -> result<bool, string>;
+    read-file: func(path: string) -> result<list<u8>, string>;
+    write-file: func(path: string, data: list<u8>) -> result<_, string>;
+    get-cwd: func() -> result<string, string>;
 }
 
 
 world typegraph {
-    export core
-    export runtimes
-    export utils
-    export aws
-    import host
+    export core;
+    export runtimes;
+    export utils;
+    export aws;
+    import host;
 }


### PR DESCRIPTION
Motivations:
* Major API changes in wasmtime that affected the type conversion
https://github.com/bytecodealliance/wasmtime/pull/8062

* Major API changes in wit-bindgen (required semicolon in wit, introduction of macro `export!(...)`)
https://github.com/bytecodealliance/wit-bindgen/releases/tag/wit-bindgen-cli-0.14.0
https://github.com/bytecodealliance/wit-bindgen/releases/tag/v0.24.0

#### Migration notes

None

<!-- 5. Readiness checklist
- [ ] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
-->
