### PR TITLE
feat(pyrt)!: `import_function` materializer support

### DIFF
--- a/ghjk.ts
+++ b/ghjk.ts
@@ -152,5 +152,6 @@ ghjk.task("build-pyrt", {
     await $`componentize-py -d ./wit/wit-wire.wit componentize -o ${wasmOut} libs.pyrt_wit_wire.main`;
     // const target = env["PYRT_TARGET"] ? `--target ${env["PYRT_TARGET"]}` : "";
     // const cwasmOut = env["PYRT_CWASM_OUT"] ?? "./target/pyrt.cwasm";
+    // await `wasmtime compile -W component-model ${target} ${wasmOut} -o ${cwasmOut}`;
   },
 });

--- a/libs/pyrt_wit_wire/main.py
+++ b/libs/pyrt_wit_wire/main.py
@@ -7,6 +7,7 @@ from wit_wire.exports.mat_wire import (
     InitArgs,
     InitResponse,
     InitError_UnexpectedMat,
+    InitError_Other,
     MatInfo,
     HandleReq,
     HandleErr_NoHandler,
@@ -17,7 +18,14 @@ from wit_wire.exports.mat_wire import (
 
 import json
 import types
-from typing import Callable, Any
+from typing import Callable, Any, Dict
+import importlib
+import importlib.util
+import importlib.abc
+import importlib.machinery
+import os
+import sys
+import traceback
 
 # the `MatWire` class is instantiated for each
 # external call. We have to put any persisted
@@ -28,12 +36,20 @@ handlers = {}
 class MatWire(wit_wire.exports.MatWire):
     def init(self, args: InitArgs):
         for op in args.expected_ops:
-            handlers[op.op_name] = op_to_handler(op)
+            try:
+                handlers[op.op_name] = op_to_handler(op)
+            except Exception as err:
+                print(f"errororororororororr {err}")
+                traceback.print_exc()
+                raise Err(InitError_Other(str(err)))
         return InitResponse(ok=True)
 
     def handle(self, req: HandleReq):
         handler = handlers.get(req.op_name)
         if handler is None:
+            print(
+                f"no handler found for {req.op_name}, registered handlers: {[op for op in handlers]}"
+            )
             raise Err(HandleErr_NoHandler())
         try:
             return handler.handle(req)
@@ -54,14 +70,94 @@ class ErasedHandler:
 
 
 def op_to_handler(op: MatInfo) -> ErasedHandler:
+    print(f"op: {op}")
     data_parsed = json.loads(op.mat_data_json)
     if data_parsed["ty"] == "def":
         module = types.ModuleType(op.op_name)
         exec(data_parsed["source"], module.__dict__)
         fn = module.__dict__[data_parsed["func_name"]]
         return ErasedHandler(handler_fn=lambda inp: fn(inp))
+    elif data_parsed["ty"] == "import_function":
+        prefix = data_parsed["func_name"]
+
+        modules_raw = data_parsed["sources"]
+        finder = ThePathFinder(
+            {os.path.join(prefix, path): modules_raw[path] for path in modules_raw}
+        )
+        sys.meta_path.append(finder)
+
+        module = importlib.import_module(
+            ThePathFinder.path_to_module(
+                os.path.join(prefix, data_parsed["root_src_path"])
+            )
+        )
+        return ErasedHandler(handler_fn=getattr(module, data_parsed["func_name"]))
     elif data_parsed["ty"] == "lambda":
         fn = eval(data_parsed["source"])
         return ErasedHandler(handler_fn=lambda inp: fn(inp))
     else:
         raise Err(InitError_UnexpectedMat(op))
+
+
+class ThePathFinder(importlib.abc.MetaPathFinder):
+    @staticmethod
+    def path_to_module(path: str):
+        return os.path.splitext((os.path.normpath(path)))[0].replace("/", ".")
+
+    def __init__(self, modules: Dict[str, str]):
+        self._mods_raw = modules
+        self._pkgs = set()
+        for path in self._mods_raw:
+            dirname = os.path.dirname(path)
+            while dirname != "/" and dirname != "" and dirname != ".":
+                if dirname not in self._mods_raw:
+                    self._pkgs.add(dirname)
+                dirname = os.path.dirname(dirname)
+        self._mod_names = {ThePathFinder.path_to_module(path): path for path in modules}
+        self._pkg_names = {
+            ThePathFinder.path_to_module(path): path for path in self._pkgs
+        }
+        print(f"modules {self._mod_names}")
+        print(f"packages {self._pkg_names}")
+
+    def find_spec(self, fullname: str, _path, target=None):
+        print(f"looking for spec {fullname}")
+        if fullname in self._mod_names:
+            path = self._mod_names[fullname]
+            return importlib.util.spec_from_loader(
+                fullname,
+                FakeFileLoader(
+                    fullname, path, src=self._mods_raw[path], is_package=False
+                ),
+            )
+        if fullname in self._pkg_names:
+            path = self._pkg_names[fullname]
+            return importlib.util.spec_from_loader(
+                fullname, FakeFileLoader(fullname, path, src="", is_package=True)
+            )
+
+
+class FakeFileLoader(importlib.abc.FileLoader):
+    def __init__(
+        self,
+        fullname: str,
+        path: str,
+        src: str,
+        is_package: bool,
+    ):
+        self.name = fullname
+        self.path = path
+        self._is_pkg = is_package
+        self._src = src
+
+    def is_package(self, fullname: str):
+        assert fullname == self.name
+        return self._is_pkg
+
+    def get_source(self, fullname: str):
+        assert fullname == self.name
+        return self._src
+
+    def get_filename(self, name=None):
+        assert name is not None and name == self.name
+        return self.path

--- a/typegate/engine/runtime.d.ts
+++ b/typegate/engine/runtime.d.ts
@@ -255,9 +255,7 @@ export type WitWireHandleResponse =
   | {
     Ok: string;
   }
-  | {
-    NoHandler: void;
-  }
+  | "NoHandler"
   | {
     InJsonErr: string;
   }

--- a/typegate/src/engine/query_engine.ts
+++ b/typegate/src/engine/query_engine.ts
@@ -287,17 +287,17 @@ export class QueryEngine {
     return await this.tg.deinit();
   }
 
-  materialize(
+  async materialize(
     stages: ComputeStage[],
     verbose: boolean,
-  ): ComputeStage[] {
+  ): Promise<ComputeStage[]> {
     const stagesMat: ComputeStage[] = [];
     const waitlist = [...stages];
 
     while (waitlist.length > 0) {
       const stage = waitlist.shift()!;
       stagesMat.push(
-        ...stage.props.runtime.materialize(stage, waitlist, verbose),
+        ...await stage.props.runtime.materialize(stage, waitlist, verbose),
       );
     }
 
@@ -336,7 +336,7 @@ export class QueryEngine {
     */
 
     // how
-    const stagesMat = this.materialize(stages, verbose);
+    const stagesMat = await this.materialize(stages, verbose);
 
     // when
     const optimizedStages = this.optimize(stagesMat, verbose);

--- a/typegate/src/runtimes/Runtime.ts
+++ b/typegate/src/runtimes/Runtime.ts
@@ -21,7 +21,7 @@ export abstract class Runtime {
     stage: ComputeStage,
     waitlist: ComputeStage[],
     verbose: boolean,
-  ): ComputeStage[];
+  ): ComputeStage[] | Promise<ComputeStage[]>;
 
   static collectRelativeStages(
     base: ComputeStage,

--- a/typegate/src/runtimes/python.ts
+++ b/typegate/src/runtimes/python.ts
@@ -10,6 +10,7 @@ import { Artifact, Materializer } from "../typegraph/types.ts";
 import * as ast from "graphql/ast";
 import { WitWireMessenger } from "./wit_wire/mod.ts";
 import { WitWireMatInfo } from "../../engine/runtime.js";
+import { sha256 } from "../crypto.ts";
 
 const _logger = getLogger(import.meta);
 
@@ -26,86 +27,98 @@ export class PythonRuntime extends Runtime {
   static async init(params: RuntimeInitParams): Promise<Runtime> {
     const { materializers, typegraphName, typegraph, typegate } = params;
 
-    const wireMatInfos = await Promise.all(materializers.map(
-      async (mat) => {
-        let matData: object;
-        switch (mat.name) {
-          case "lambda":
-            matData = {
-              ty: "lambda",
-              source: mat.data.fn as string,
-              effect: mat.effect,
-            };
-            break;
-          case "def":
-            matData = {
-              ty: "def",
-              source: mat.data.fn as string,
-              func_name: mat.data.name as string,
-              effect: mat.effect,
-            };
-            break;
-          case "import_function": {
-            const pyModMat = typegraph.materializers[mat.data.mod as number];
+    const wireMatInfos = await Promise.all(
+      materializers
+        .filter((mat) => mat.name != "pymodule")
+        .map(
+          async (mat) => {
+            let matInfoData: object;
+            switch (mat.name) {
+              case "lambda":
+                matInfoData = {
+                  ty: "lambda",
+                  effect: mat.effect,
+                  source: mat.data.fn as string,
+                };
+                break;
+              case "def":
+                matInfoData = {
+                  ty: "def",
+                  func_name: mat.data.name as string,
+                  effect: mat.effect,
+                  source: mat.data.fn as string,
+                };
+                break;
+              case "import_function": {
+                const pyModMat =
+                  typegraph.materializers[mat.data.mod as number];
 
-            // resolve the python module artifacts/files
-            const { pythonArtifact, depsMeta: depArtifacts } = pyModMat.data;
+                // resolve the python module artifacts/files
+                const { pythonArtifact, depsMeta: depArtifacts } =
+                  pyModMat.data;
 
-            const deps = depArtifacts as Artifact[];
-            const artifact = pythonArtifact as Artifact;
+                const deps = depArtifacts as Artifact[];
+                const artifact = pythonArtifact as Artifact;
 
-            const sources = Object.fromEntries(
-              await Promise.all(
-                [
-                  {
-                    typegraphName: typegraphName,
-                    relativePath: artifact.path,
-                    hash: artifact.hash,
-                    sizeInBytes: artifact.size,
-                  },
-                  ...deps.map((dep) => {
-                    return {
-                      typegraphName: typegraphName,
-                      relativePath: dep.path,
-                      hash: dep.hash,
-                      sizeInBytes: dep.size,
-                    };
-                  }),
-                ].map(
-                  async (meta) =>
+                const sources = Object.fromEntries(
+                  await Promise.all(
                     [
-                      meta.relativePath,
-                      await Deno.readTextFile(
-                        await typegate.artifactStore.getLocalPath(meta),
-                      ),
-                    ] as const,
-                ),
-              ),
-            );
+                      {
+                        typegraphName: typegraphName,
+                        relativePath: artifact.path,
+                        hash: artifact.hash,
+                        sizeInBytes: artifact.size,
+                      },
+                      ...deps.map((dep) => {
+                        return {
+                          typegraphName: typegraphName,
+                          relativePath: dep.path,
+                          hash: dep.hash,
+                          sizeInBytes: dep.size,
+                        };
+                      }),
+                    ].map(
+                      async (meta) =>
+                        [
+                          meta.relativePath,
+                          await Deno.readTextFile(
+                            await typegate.artifactStore.getLocalPath(meta),
+                          ),
+                        ] as const,
+                    ),
+                  ),
+                );
 
-            matData = {
-              ty: "import_function",
-              effect: mat.effect,
-              sources,
-              rootSourcePath: artifact.path,
-              func_name: mat.data.name as string,
+                matInfoData = {
+                  ty: "import_function",
+                  effect: mat.effect,
+                  root_src_path: artifact.path,
+                  func_name: mat.data.name as string,
+                  sources,
+                };
+                break;
+              }
+              default:
+                throw new Error(`unsupported materializer type: ${mat.name}`);
+            }
+
+            // TODO: use materializer type node hash instead
+            const dataHash = await sha256(JSON.stringify(mat.data));
+            const op_name = `${mat.data.name as string}_${
+              dataHash.slice(0, 12)
+            }`;
+
+            const out: WitWireMatInfo = {
+              op_name,
+              mat_hash: dataHash,
+              // TODO: source title of materializer type?
+              mat_title: mat.data.name as string,
+              mat_data_json: JSON.stringify(matInfoData),
             };
-            break;
-          }
-          default:
-            throw new Error(`unsupported materializer type: ${mat.name}`);
-        }
-        const out: WitWireMatInfo = {
-          op_name: mat.data.name as string,
-          // TODO: hashing
-          mat_hash: mat.data.name as string,
-          // TODO: title of materializer type?
-          mat_title: mat.data.name as string,
-          mat_data_json: JSON.stringify(matData),
-        };
-        return out;
-      },
-    ));
+            return out;
+          },
+        ),
+    );
 
     // add default vm for lambda/def
     const uuid = crypto.randomUUID();
@@ -122,11 +135,11 @@ export class PythonRuntime extends Runtime {
     await using _drop = this.wire;
   }
 
-  materialize(
+  async materialize(
     stage: ComputeStage,
     _waitlist: ComputeStage[],
     _verbose: boolean,
-  ): ComputeStage[] {
+  ): Promise<ComputeStage[]> {
     if (stage.props.node === "__typename") {
       return [stage.withResolver(() => {
         const { parent: parentStage } = stage.props;
@@ -148,8 +161,9 @@ export class PythonRuntime extends Runtime {
 
     if (stage.props.materializer != null) {
       const mat = stage.props.materializer;
+
       return [
-        stage.withResolver(this.delegate(mat)),
+        stage.withResolver(await this.delegate(mat)),
       ];
     }
 
@@ -166,8 +180,10 @@ export class PythonRuntime extends Runtime {
     })];
   }
 
-  delegate(mat: Materializer): Resolver {
+  async delegate(mat: Materializer): Promise<Resolver> {
     const { name } = mat.data;
-    return (args) => this.wire.handle(name as string, args);
+    const dataHash = await sha256(JSON.stringify(mat.data));
+    const op_name = `${name as string}_${dataHash.slice(0, 12)}`;
+    return (args) => this.wire.handle(op_name, args);
   }
 }

--- a/typegate/src/services/auth/protocols/oauth2.ts
+++ b/typegate/src/services/auth/protocols/oauth2.ts
@@ -78,7 +78,7 @@ class AuthProfiler {
     validatorInputWeak(input);
 
     // Note: this assumes func is a simple t.func(inp, out, mat)
-    const stages = runtime.materialize(
+    const stages = await runtime.materialize(
       this.getComputeStage(),
       [],
       true,

--- a/typegate/src/services/graphql_service.ts
+++ b/typegate/src/services/graphql_service.ts
@@ -115,7 +115,9 @@ export async function handleGraphQL(
     } else {
       logger.error(`request err: ${Deno.inspect(e)}`);
       if (e.cause) {
-        logger.error(e.cause);
+        logger.error(
+          Deno.inspect(e.cause, { strAbbreviateSize: 1024, depth: 10 }),
+        );
       }
       return jsonError(e.message, headers, 400);
     }

--- a/typegate/tests/runtimes/python/py/hello.py
+++ b/typegate/tests/runtimes/python/py/hello.py
@@ -1,9 +1,10 @@
-from nested.dep import hello
+from .nested.dep import hello
+from typing import Dict
 
 
-def sayHello(x: any):
+def sayHello(x: Dict):
     return hello(x["name"])
 
 
-def identity(x: any):
+def identity(x: Dict):
     return x["input"]

--- a/typegate/tests/runtimes/python/python.py
+++ b/typegate/tests/runtimes/python/python.py
@@ -61,13 +61,13 @@ def python(g: Graph):
             t.string(),
             test,
         ).with_policy(public),
-        # testMod=python.import_(
-        #     t.struct({"name": t.string()}),
-        #     t.string(),
-        #     module="py/hello.py",
-        #     deps=["py/nested/dep.py"],
-        #     name="sayHello",
-        # ).with_policy(public),
+        testMod=python.import_(
+            t.struct({"name": t.string()}),
+            t.string(),
+            module="py/hello.py",
+            deps=["py/nested/dep.py"],
+            name="sayHello",
+        ).with_policy(public),
         identity=python.from_def(
             t.struct({"input": tpe}),
             tpe,

--- a/typegate/tests/runtimes/python/python.ts
+++ b/typegate/tests/runtimes/python/python.ts
@@ -30,7 +30,7 @@ export const tg = await typegraph("python", (g: any) => {
         `,
       },
     ).withPolicy(pub),
-    /* identityMod: python.import(
+    identityMod: python.import(
       t.struct({ input: tpe }),
       tpe,
       {
@@ -38,6 +38,6 @@ export const tg = await typegraph("python", (g: any) => {
         module: "py/hello.py",
         deps: ["py/nested/dep.py"],
       },
-    ).withPolicy(pub), */
+    ).withPolicy(pub),
   });
 });

--- a/typegate/tests/runtimes/python/python_test.ts
+++ b/typegate/tests/runtimes/python/python_test.ts
@@ -140,7 +140,7 @@ Meta.test(
         .on(e);
     });
 
-    /* await t.should("work once (module)", async () => {
+    await t.should("work once (module)", async () => {
       await gql`
         query {
           testMod(name: "Loyd")
@@ -150,7 +150,7 @@ Meta.test(
           testMod: "Hello Loyd",
         })
         .on(e);
-    }); */
+    });
 
     await t.should("return same object", async () => {
       await gql`
@@ -270,7 +270,7 @@ Meta.test(
   },
 );
 
-/* Meta.test(
+Meta.test(
   {
     name: "Python: upload artifacts with deps",
     port: true,
@@ -320,7 +320,7 @@ Meta.test(
         .on(engine);
     });
   },
-); */
+);
 
 Meta.test(
   {
@@ -409,10 +409,10 @@ Meta.test(
             a
             b
           }
-          # identityMod(input: { a: "hello", b: [1, 2, "three"] }) {
-          #   a
-          #   b
-          # }
+          identityMod(input: { a: "hello", b: [1, 2, "three"] }) {
+            a
+            b
+          }
         }
       `
         .expectData({
@@ -424,10 +424,10 @@ Meta.test(
             a: "hello",
             b: [1, 2, "three"],
           },
-          /* identityMod: {
+          identityMod: {
             a: "hello",
             b: [1, 2, "three"],
-          }, */
+          },
         })
         .on(currentEngine);
     };


### PR DESCRIPTION
Implements python runtime support for `import_function` materializers. This is an stacked PR on #673 which itself is appended on #687 for tackling MET-404.

#### Migration notes

This PR introduced a breaking change in the importer logic for python modules brought in through `pyrt.import_` and it's deps. After this PR, any path imports must be prefixed with `.`, `..`, `...` and so to point to relative path locations. This behavior is at odds with standard python which looks for relative modules and packages even if there are no dot prefixes.

- [x] The change come with new or modified tests
- [x] Hard-to-understand functions have explanatory comments
<!-- 5. Readiness checklist
- [ ] End-user documentation is updated to reflect the change
-->
