### PR TITLE
chore: bump temporal_cli to 0.13.1

### DIFF
--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -619,6 +619,12 @@
           "buildDepConfigs": {},
           "portRef": "jq_ghrel@0.1.0",
           "specifiedVersion": false
+        },
+        "bciqbbuzvdy4qweoxykn6kcqp3xyoi2ehdbdv3xbir4inj6i3m72wcsa": {
+          "version": "v0.13.1",
+          "buildDepConfigs": {},
+          "portRef": "temporal_cli_ghrel@0.1.0",
+          "specifiedVersion": true
         }
       }
     },
@@ -656,7 +662,7 @@
                 "bciqklnhhbhk3a4jgkm2azdm63nimlphee7bq5cpewg6tqgei624egzq",
                 "bciqltjx5hrqf2qxibmasyab2aac23ovagtny5eu7xkr7kk66dsqicxq",
                 "bciqklz4j7zc46l4lwzjjpdradi6sy4mfd5ey27rrslcfxrdcvtek5ya",
-                "bciqenhfcywf2fzbiepze5vobqxh5yeklgbtftcosmi27avmpu7v7tla",
+                "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy",
                 "bciqf62kkjssayjkrr36rr3x3hrpiwiirlmn4exjz46veeaxp32bdqna",
                 "bciqa6vvvgr27kbbhvyc6hfbszfjkc5x4tssqicefmmljx2myuqwokdq",
                 "bciqncucmifodexsndv3z3yycgkxuijyh52qftnb4tdh7h32uazdhkuq",
@@ -706,7 +712,7 @@
             "ghjkEnvProvInstSet___ci": {
               "installs": [
                 "bciqklz4j7zc46l4lwzjjpdradi6sy4mfd5ey27rrslcfxrdcvtek5ya",
-                "bciqenhfcywf2fzbiepze5vobqxh5yeklgbtftcosmi27avmpu7v7tla",
+                "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy",
                 "bciqf62kkjssayjkrr36rr3x3hrpiwiirlmn4exjz46veeaxp32bdqna",
                 "bciqa6vvvgr27kbbhvyc6hfbszfjkc5x4tssqicefmmljx2myuqwokdq",
                 "bciqncucmifodexsndv3z3yycgkxuijyh52qftnb4tdh7h32uazdhkuq",
@@ -2370,8 +2376,8 @@
         },
         "packageName": "pre-commit"
       },
-      "bciqenhfcywf2fzbiepze5vobqxh5yeklgbtftcosmi27avmpu7v7tla": {
-        "version": "v0.10.7",
+      "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy": {
+        "version": "v0.13.1",
         "port": {
           "ty": "denoWorker@v1",
           "name": "temporal_cli_ghrel",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
           ghjk x install-lsp
           ghjk x fetch-deno
 
-          pre-commit run --show-diff-on-failure --color=always --all-files
+          SKIP=ghjk-resolve pre-commit run --show-diff-on-failure --color=always --all-files
 
   lint-compat:
     needs: changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: local
     hooks:
-      - id: version
+      - id: ghjk-resolve
         name: "Resolve ghjk installs"
         always_run: true
         language: system
@@ -19,7 +19,7 @@ repos:
         language: system
         entry: bash -c 'poetry -C ./typegraph/python check --lock'
         pass_filenames: false
-      - id: version
+      - id: sed-lock
         name: "Lock versions"
         always_run: true
         language: system

--- a/ghjk.ts
+++ b/ghjk.ts
@@ -33,9 +33,9 @@ env("main")
     CLICOLOR_FORCE: "1",
   })
   .allowedBuildDeps(
+    ...stdDeps(),
     installs.python_latest,
     installs.node,
-    ...stdDeps(),
   );
 
 env("_rust")
@@ -102,7 +102,7 @@ env("ci")
   .inherit(["_rust", "_python", "_ecma", "_wasm"])
   .install(
     ports.pipi({ packageName: "pre-commit", version: "3.7.1" })[0],
-    ports.temporal_cli({ version: "v0.10.7" }),
+    ports.temporal_cli({ version: "v0.13.1" }),
     ports.cargobi({
       crateName: "cargo-insta",
       version: "1.33.0",

--- a/typegate/tests/runtimes/temporal/temporal_test.ts
+++ b/typegate/tests/runtimes/temporal/temporal_test.ts
@@ -54,7 +54,7 @@ Meta.test("temporal integ", async (t) => {
 
   greenFlag.push(waitForHealthy(
     temporalProc,
-    "Frontend is now healthy",
+    "Temporal server: ",
     "stdout",
   ));
 


### PR DESCRIPTION
- Bump the temporal cli used by the tests to 0.13.1
 
Motivated by the flakey temporal issue. [This](https://github.com/metatypedev/metatype/actions/runs/9264921959/job/25488342071#step:10:16890) line seems to be the key issue which leads me to [this](https://github.com/temporalio/temporal/issues/5123) ticket upstream. It was fixed back in November it seems and moving to the latest version of the temporal server should help solve the issue.

This PR is a stacked diff on top of #754 

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
