### PR TITLE
chore: add programmatic deploy tests

### DIFF
--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -1,6 +1,6 @@
 {
   "version": "0",
-  "platform": "x86_64-linux",
+  "platform": "aarch64-darwin",
   "moduleEntries": {
     "ports": {
       "version": "0",
@@ -649,32 +649,6 @@
               ],
               "allowedBuildDeps": "bciqduqrotwckptiuy7f6med5uixh7bq2csx6crdbk5wcytpvzanqcoy"
             },
-            "ghjkEnvProvInstSet___dev": {
-              "installs": [
-                "bciqdvjio2pm2doenrjto6ie2rooebfzk36rfdqfhp764gynvwwwlzli",
-                "bciqbs34bxkpv5splgajo6lbi7qabrvfygukt23qjtkk3qqf2vxsw46a",
-                "bciqklnhhbhk3a4jgkm2azdm63nimlphee7bq5cpewg6tqgei624egzq",
-                "bciqltjx5hrqf2qxibmasyab2aac23ovagtny5eu7xkr7kk66dsqicxq",
-                "bciqklz4j7zc46l4lwzjjpdradi6sy4mfd5ey27rrslcfxrdcvtek5ya",
-                "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy",
-                "bciqf62kkjssayjkrr36rr3x3hrpiwiirlmn4exjz46veeaxp32bdqna",
-                "bciqa6vvvgr27kbbhvyc6hfbszfjkc5x4tssqicefmmljx2myuqwokdq",
-                "bciqncucmifodexsndv3z3yycgkxuijyh52qftnb4tdh7h32uazdhkuq",
-                "bciqccbophtq6t76vohd2mz5tojllwcha3sfozbllmpodr3uwkmmshzi",
-                "bciqdagddr7ykkiri2l6xx6kpziflufklhdf6qtzruq7pi766ywwzokq",
-                "bciqd67xvzjx5rhilxs3c2zzjhfgqynhqywqosjvyo4jyyu3ykgsgdgy",
-                "bciqgz7rew65ut3nwunl2qmmlshqmmsgybqsgn4ekzz7fn3322hu3keq",
-                "bciqf6xkaxfvapwn3bf73vnqzr7mkcxgghwdh24uhgnozbz7wsdl2rrq",
-                "bciqk7kzquppicvwdz2erhbkqu5gwzojtbjbk5gzjau2zo6xaf6x7kpa",
-                "bciqkfsvzlt23celx7huie2ilyelz6pbtumsxto3vsyocprrezxrvrha",
-                "bciqjij47lkh2rdkrz3jc6wmevbfjkpueih33izmmf3xuycbyokkfweq",
-                "bciqfgnjbpohl4jn7hh72iz6mtwos4js72xg7oipbqxsvjykm7errgka",
-                "bciqpszk4pvfknr65scs2bsuo2j372lbc4ywb52uq6ljtksppxbt6uwy",
-                "bciqcraurpl4pijby6dmkuzevrupqwxoupubzke476koiigkljrpszuy",
-                "bciqdjlgjjtjbt4h7wiexadsws7kef7d4jikwgfq66ijr52gfyrnvaqq"
-              ],
-              "allowedBuildDeps": "bciqduqrotwckptiuy7f6med5uixh7bq2csx6crdbk5wcytpvzanqcoy"
-            },
             "ghjkEnvProvInstSet____ecma": {
               "installs": [
                 "bciqk7kzquppicvwdz2erhbkqu5gwzojtbjbk5gzjau2zo6xaf6x7kpa",
@@ -705,6 +679,31 @@
             },
             "ghjkEnvProvInstSet___ci": {
               "installs": [
+                "bciqklz4j7zc46l4lwzjjpdradi6sy4mfd5ey27rrslcfxrdcvtek5ya",
+                "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy",
+                "bciqf62kkjssayjkrr36rr3x3hrpiwiirlmn4exjz46veeaxp32bdqna",
+                "bciqa6vvvgr27kbbhvyc6hfbszfjkc5x4tssqicefmmljx2myuqwokdq",
+                "bciqncucmifodexsndv3z3yycgkxuijyh52qftnb4tdh7h32uazdhkuq",
+                "bciqccbophtq6t76vohd2mz5tojllwcha3sfozbllmpodr3uwkmmshzi",
+                "bciqdagddr7ykkiri2l6xx6kpziflufklhdf6qtzruq7pi766ywwzokq",
+                "bciqd67xvzjx5rhilxs3c2zzjhfgqynhqywqosjvyo4jyyu3ykgsgdgy",
+                "bciqgz7rew65ut3nwunl2qmmlshqmmsgybqsgn4ekzz7fn3322hu3keq",
+                "bciqf6xkaxfvapwn3bf73vnqzr7mkcxgghwdh24uhgnozbz7wsdl2rrq",
+                "bciqk7kzquppicvwdz2erhbkqu5gwzojtbjbk5gzjau2zo6xaf6x7kpa",
+                "bciqkfsvzlt23celx7huie2ilyelz6pbtumsxto3vsyocprrezxrvrha",
+                "bciqjij47lkh2rdkrz3jc6wmevbfjkpueih33izmmf3xuycbyokkfweq",
+                "bciqfgnjbpohl4jn7hh72iz6mtwos4js72xg7oipbqxsvjykm7errgka",
+                "bciqpszk4pvfknr65scs2bsuo2j372lbc4ywb52uq6ljtksppxbt6uwy",
+                "bciqcraurpl4pijby6dmkuzevrupqwxoupubzke476koiigkljrpszuy",
+                "bciqdjlgjjtjbt4h7wiexadsws7kef7d4jikwgfq66ijr52gfyrnvaqq"
+              ],
+              "allowedBuildDeps": "bciqduqrotwckptiuy7f6med5uixh7bq2csx6crdbk5wcytpvzanqcoy"
+            },
+            "ghjkEnvProvInstSet___dev": {
+              "installs": [
+                "bciqbs34bxkpv5splgajo6lbi7qabrvfygukt23qjtkk3qqf2vxsw46a",
+                "bciqklnhhbhk3a4jgkm2azdm63nimlphee7bq5cpewg6tqgei624egzq",
+                "bciqltjx5hrqf2qxibmasyab2aac23ovagtny5eu7xkr7kk66dsqicxq",
                 "bciqklz4j7zc46l4lwzjjpdradi6sy4mfd5ey27rrslcfxrdcvtek5ya",
                 "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy",
                 "bciqf62kkjssayjkrr36rr3x3hrpiwiirlmn4exjz46veeaxp32bdqna",
@@ -2212,14 +2211,18 @@
         },
         "packageName": "cmake"
       },
-      "bciqdvjio2pm2doenrjto6ie2rooebfzk36rfdqfhp764gynvwwwlzli": {
-        "version": "v2.4.0",
+      "bciqk7kzquppicvwdz2erhbkqu5gwzojtbjbk5gzjau2zo6xaf6x7kpa": {
+        "version": "20.8.0",
         "port": {
           "ty": "denoWorker@v1",
-          "name": "mold_ghrel",
+          "name": "node_org",
           "platforms": [
             "aarch64-linux",
-            "x86_64-linux"
+            "x86_64-linux",
+            "aarch64-darwin",
+            "x86_64-darwin",
+            "aarch64-windows",
+            "x86_64-windows"
           ],
           "version": "0.1.0",
           "buildDeps": [
@@ -2227,14 +2230,14 @@
               "name": "tar_aa"
             }
           ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/mold.ts"
-        },
-        "replaceLd": true
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/node.ts"
+        }
       },
-      "bciqbs34bxkpv5splgajo6lbi7qabrvfygukt23qjtkk3qqf2vxsw46a": {
+      "bciqkfsvzlt23celx7huie2ilyelz6pbtumsxto3vsyocprrezxrvrha": {
+        "version": "v9.4.0",
         "port": {
           "ty": "denoWorker@v1",
-          "name": "act_ghrel",
+          "name": "pnpm_ghrel",
           "platforms": [
             "aarch64-linux",
             "x86_64-linux",
@@ -2244,19 +2247,14 @@
             "x86_64-windows"
           ],
           "version": "0.1.0",
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/act.ts"
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/pnpm.ts"
         }
       },
-      "bciqklnhhbhk3a4jgkm2azdm63nimlphee7bq5cpewg6tqgei624egzq": {
-        "buildDepConfigs": {
-          "rust_rustup": {
-            "portRef": "rust_rustup@0.1.0",
-            "profile": "minimal"
-          }
-        },
+      "bciqjij47lkh2rdkrz3jc6wmevbfjkpueih33izmmf3xuycbyokkfweq": {
+        "version": "10.0.1",
         "port": {
           "ty": "denoWorker@v1",
-          "name": "cargobi_cratesio",
+          "name": "npmi_npm",
           "platforms": [
             "x86_64-linux",
             "aarch64-linux",
@@ -2280,202 +2278,12 @@
           "version": "0.1.0",
           "buildDeps": [
             {
-              "name": "cargo_binstall_ghrel"
-            },
-            {
-              "name": "rust_rustup"
+              "name": "node_org"
             }
           ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/npmi.ts"
         },
-        "crateName": "whiz",
-        "locked": true
-      },
-      "bciqltjx5hrqf2qxibmasyab2aac23ovagtny5eu7xkr7kk66dsqicxq": {
-        "buildDepConfigs": {
-          "rust_rustup": {
-            "portRef": "rust_rustup@0.1.0",
-            "profile": "minimal"
-          }
-        },
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "cargobi_cratesio",
-          "platforms": [
-            "x86_64-linux",
-            "aarch64-linux",
-            "x86_64-darwin",
-            "aarch64-darwin",
-            "x86_64-windows",
-            "aarch64-windows",
-            "x86_64-freebsd",
-            "aarch64-freebsd",
-            "x86_64-netbsd",
-            "aarch64-netbsd",
-            "x86_64-aix",
-            "aarch64-aix",
-            "x86_64-solaris",
-            "aarch64-solaris",
-            "x86_64-illumos",
-            "aarch64-illumos",
-            "x86_64-android",
-            "aarch64-android"
-          ],
-          "version": "0.1.0",
-          "buildDeps": [
-            {
-              "name": "cargo_binstall_ghrel"
-            },
-            {
-              "name": "rust_rustup"
-            }
-          ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
-        },
-        "crateName": "wit-deps-cli",
-        "locked": true
-      },
-      "bciqklz4j7zc46l4lwzjjpdradi6sy4mfd5ey27rrslcfxrdcvtek5ya": {
-        "version": "3.7.1",
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "pipi_pypi",
-          "platforms": [
-            "x86_64-linux",
-            "aarch64-linux",
-            "x86_64-darwin",
-            "aarch64-darwin",
-            "x86_64-windows",
-            "aarch64-windows",
-            "x86_64-freebsd",
-            "aarch64-freebsd",
-            "x86_64-netbsd",
-            "aarch64-netbsd",
-            "x86_64-aix",
-            "aarch64-aix",
-            "x86_64-solaris",
-            "aarch64-solaris",
-            "x86_64-illumos",
-            "aarch64-illumos",
-            "x86_64-android",
-            "aarch64-android"
-          ],
-          "version": "0.1.0",
-          "buildDeps": [
-            {
-              "name": "cpy_bs_ghrel"
-            }
-          ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/pipi.ts"
-        },
-        "packageName": "pre-commit"
-      },
-      "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy": {
-        "version": "v0.13.1",
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "temporal_cli_ghrel",
-          "platforms": [
-            "aarch64-linux",
-            "x86_64-linux",
-            "aarch64-darwin",
-            "x86_64-darwin",
-            "aarch64-windows",
-            "x86_64-windows"
-          ],
-          "version": "0.1.0",
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/temporal_cli.ts"
-        }
-      },
-      "bciqf62kkjssayjkrr36rr3x3hrpiwiirlmn4exjz46veeaxp32bdqna": {
-        "version": "1.33.0",
-        "buildDepConfigs": {
-          "rust_rustup": {
-            "portRef": "rust_rustup@0.1.0",
-            "profile": "minimal"
-          }
-        },
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "cargobi_cratesio",
-          "platforms": [
-            "x86_64-linux",
-            "aarch64-linux",
-            "x86_64-darwin",
-            "aarch64-darwin",
-            "x86_64-windows",
-            "aarch64-windows",
-            "x86_64-freebsd",
-            "aarch64-freebsd",
-            "x86_64-netbsd",
-            "aarch64-netbsd",
-            "x86_64-aix",
-            "aarch64-aix",
-            "x86_64-solaris",
-            "aarch64-solaris",
-            "x86_64-illumos",
-            "aarch64-illumos",
-            "x86_64-android",
-            "aarch64-android"
-          ],
-          "version": "0.1.0",
-          "buildDeps": [
-            {
-              "name": "cargo_binstall_ghrel"
-            },
-            {
-              "name": "rust_rustup"
-            }
-          ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
-        },
-        "crateName": "cargo-insta",
-        "locked": true
-      },
-      "bciqa6vvvgr27kbbhvyc6hfbszfjkc5x4tssqicefmmljx2myuqwokdq": {
-        "version": "0.2.5",
-        "buildDepConfigs": {
-          "rust_rustup": {
-            "portRef": "rust_rustup@0.1.0",
-            "profile": "minimal"
-          }
-        },
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "cargobi_cratesio",
-          "platforms": [
-            "x86_64-linux",
-            "aarch64-linux",
-            "x86_64-darwin",
-            "aarch64-darwin",
-            "x86_64-windows",
-            "aarch64-windows",
-            "x86_64-freebsd",
-            "aarch64-freebsd",
-            "x86_64-netbsd",
-            "aarch64-netbsd",
-            "x86_64-aix",
-            "aarch64-aix",
-            "x86_64-solaris",
-            "aarch64-solaris",
-            "x86_64-illumos",
-            "aarch64-illumos",
-            "x86_64-android",
-            "aarch64-android"
-          ],
-          "version": "0.1.0",
-          "buildDeps": [
-            {
-              "name": "cargo_binstall_ghrel"
-            },
-            {
-              "name": "rust_rustup"
-            }
-          ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
-        },
-        "crateName": "cross",
-        "locked": true
+        "packageName": "node-gyp"
       },
       "bciqd67xvzjx5rhilxs3c2zzjhfgqynhqywqosjvyo4jyyu3ykgsgdgy": {
         "version": "3.8.18",
@@ -2572,80 +2380,6 @@
           "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/pipi.ts"
         },
         "packageName": "poetry"
-      },
-      "bciqk7kzquppicvwdz2erhbkqu5gwzojtbjbk5gzjau2zo6xaf6x7kpa": {
-        "version": "20.8.0",
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "node_org",
-          "platforms": [
-            "aarch64-linux",
-            "x86_64-linux",
-            "aarch64-darwin",
-            "x86_64-darwin",
-            "aarch64-windows",
-            "x86_64-windows"
-          ],
-          "version": "0.1.0",
-          "buildDeps": [
-            {
-              "name": "tar_aa"
-            }
-          ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/node.ts"
-        }
-      },
-      "bciqkfsvzlt23celx7huie2ilyelz6pbtumsxto3vsyocprrezxrvrha": {
-        "version": "v9.4.0",
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "pnpm_ghrel",
-          "platforms": [
-            "aarch64-linux",
-            "x86_64-linux",
-            "aarch64-darwin",
-            "x86_64-darwin",
-            "aarch64-windows",
-            "x86_64-windows"
-          ],
-          "version": "0.1.0",
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/pnpm.ts"
-        }
-      },
-      "bciqjij47lkh2rdkrz3jc6wmevbfjkpueih33izmmf3xuycbyokkfweq": {
-        "version": "10.0.1",
-        "port": {
-          "ty": "denoWorker@v1",
-          "name": "npmi_npm",
-          "platforms": [
-            "x86_64-linux",
-            "aarch64-linux",
-            "x86_64-darwin",
-            "aarch64-darwin",
-            "x86_64-windows",
-            "aarch64-windows",
-            "x86_64-freebsd",
-            "aarch64-freebsd",
-            "x86_64-netbsd",
-            "aarch64-netbsd",
-            "x86_64-aix",
-            "aarch64-aix",
-            "x86_64-solaris",
-            "aarch64-solaris",
-            "x86_64-illumos",
-            "aarch64-illumos",
-            "x86_64-android",
-            "aarch64-android"
-          ],
-          "version": "0.1.0",
-          "buildDeps": [
-            {
-              "name": "node_org"
-            }
-          ],
-          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/npmi.ts"
-        },
-        "packageName": "node-gyp"
       },
       "bciqfgnjbpohl4jn7hh72iz6mtwos4js72xg7oipbqxsvjykm7errgka": {
         "version": "0.116.1",
@@ -2806,6 +2540,252 @@
           "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/npmi.ts"
         },
         "packageName": "@bytecodealliance/jco"
+      },
+      "bciqklz4j7zc46l4lwzjjpdradi6sy4mfd5ey27rrslcfxrdcvtek5ya": {
+        "version": "3.7.1",
+        "port": {
+          "ty": "denoWorker@v1",
+          "name": "pipi_pypi",
+          "platforms": [
+            "x86_64-linux",
+            "aarch64-linux",
+            "x86_64-darwin",
+            "aarch64-darwin",
+            "x86_64-windows",
+            "aarch64-windows",
+            "x86_64-freebsd",
+            "aarch64-freebsd",
+            "x86_64-netbsd",
+            "aarch64-netbsd",
+            "x86_64-aix",
+            "aarch64-aix",
+            "x86_64-solaris",
+            "aarch64-solaris",
+            "x86_64-illumos",
+            "aarch64-illumos",
+            "x86_64-android",
+            "aarch64-android"
+          ],
+          "version": "0.1.0",
+          "buildDeps": [
+            {
+              "name": "cpy_bs_ghrel"
+            }
+          ],
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/pipi.ts"
+        },
+        "packageName": "pre-commit"
+      },
+      "bciqhw6s67have7n4q3kefgvuekg7gktbkkvleadoufl2wpxzag3psyy": {
+        "version": "v0.13.1",
+        "port": {
+          "ty": "denoWorker@v1",
+          "name": "temporal_cli_ghrel",
+          "platforms": [
+            "aarch64-linux",
+            "x86_64-linux",
+            "aarch64-darwin",
+            "x86_64-darwin",
+            "aarch64-windows",
+            "x86_64-windows"
+          ],
+          "version": "0.1.0",
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/temporal_cli.ts"
+        }
+      },
+      "bciqf62kkjssayjkrr36rr3x3hrpiwiirlmn4exjz46veeaxp32bdqna": {
+        "version": "1.33.0",
+        "buildDepConfigs": {
+          "rust_rustup": {
+            "portRef": "rust_rustup@0.1.0",
+            "profile": "minimal"
+          }
+        },
+        "port": {
+          "ty": "denoWorker@v1",
+          "name": "cargobi_cratesio",
+          "platforms": [
+            "x86_64-linux",
+            "aarch64-linux",
+            "x86_64-darwin",
+            "aarch64-darwin",
+            "x86_64-windows",
+            "aarch64-windows",
+            "x86_64-freebsd",
+            "aarch64-freebsd",
+            "x86_64-netbsd",
+            "aarch64-netbsd",
+            "x86_64-aix",
+            "aarch64-aix",
+            "x86_64-solaris",
+            "aarch64-solaris",
+            "x86_64-illumos",
+            "aarch64-illumos",
+            "x86_64-android",
+            "aarch64-android"
+          ],
+          "version": "0.1.0",
+          "buildDeps": [
+            {
+              "name": "cargo_binstall_ghrel"
+            },
+            {
+              "name": "rust_rustup"
+            }
+          ],
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
+        },
+        "crateName": "cargo-insta",
+        "locked": true
+      },
+      "bciqa6vvvgr27kbbhvyc6hfbszfjkc5x4tssqicefmmljx2myuqwokdq": {
+        "version": "0.2.5",
+        "buildDepConfigs": {
+          "rust_rustup": {
+            "portRef": "rust_rustup@0.1.0",
+            "profile": "minimal"
+          }
+        },
+        "port": {
+          "ty": "denoWorker@v1",
+          "name": "cargobi_cratesio",
+          "platforms": [
+            "x86_64-linux",
+            "aarch64-linux",
+            "x86_64-darwin",
+            "aarch64-darwin",
+            "x86_64-windows",
+            "aarch64-windows",
+            "x86_64-freebsd",
+            "aarch64-freebsd",
+            "x86_64-netbsd",
+            "aarch64-netbsd",
+            "x86_64-aix",
+            "aarch64-aix",
+            "x86_64-solaris",
+            "aarch64-solaris",
+            "x86_64-illumos",
+            "aarch64-illumos",
+            "x86_64-android",
+            "aarch64-android"
+          ],
+          "version": "0.1.0",
+          "buildDeps": [
+            {
+              "name": "cargo_binstall_ghrel"
+            },
+            {
+              "name": "rust_rustup"
+            }
+          ],
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
+        },
+        "crateName": "cross",
+        "locked": true
+      },
+      "bciqbs34bxkpv5splgajo6lbi7qabrvfygukt23qjtkk3qqf2vxsw46a": {
+        "port": {
+          "ty": "denoWorker@v1",
+          "name": "act_ghrel",
+          "platforms": [
+            "aarch64-linux",
+            "x86_64-linux",
+            "aarch64-darwin",
+            "x86_64-darwin",
+            "aarch64-windows",
+            "x86_64-windows"
+          ],
+          "version": "0.1.0",
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/act.ts"
+        }
+      },
+      "bciqklnhhbhk3a4jgkm2azdm63nimlphee7bq5cpewg6tqgei624egzq": {
+        "buildDepConfigs": {
+          "rust_rustup": {
+            "portRef": "rust_rustup@0.1.0",
+            "profile": "minimal"
+          }
+        },
+        "port": {
+          "ty": "denoWorker@v1",
+          "name": "cargobi_cratesio",
+          "platforms": [
+            "x86_64-linux",
+            "aarch64-linux",
+            "x86_64-darwin",
+            "aarch64-darwin",
+            "x86_64-windows",
+            "aarch64-windows",
+            "x86_64-freebsd",
+            "aarch64-freebsd",
+            "x86_64-netbsd",
+            "aarch64-netbsd",
+            "x86_64-aix",
+            "aarch64-aix",
+            "x86_64-solaris",
+            "aarch64-solaris",
+            "x86_64-illumos",
+            "aarch64-illumos",
+            "x86_64-android",
+            "aarch64-android"
+          ],
+          "version": "0.1.0",
+          "buildDeps": [
+            {
+              "name": "cargo_binstall_ghrel"
+            },
+            {
+              "name": "rust_rustup"
+            }
+          ],
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
+        },
+        "crateName": "whiz",
+        "locked": true
+      },
+      "bciqltjx5hrqf2qxibmasyab2aac23ovagtny5eu7xkr7kk66dsqicxq": {
+        "buildDepConfigs": {
+          "rust_rustup": {
+            "portRef": "rust_rustup@0.1.0",
+            "profile": "minimal"
+          }
+        },
+        "port": {
+          "ty": "denoWorker@v1",
+          "name": "cargobi_cratesio",
+          "platforms": [
+            "x86_64-linux",
+            "aarch64-linux",
+            "x86_64-darwin",
+            "aarch64-darwin",
+            "x86_64-windows",
+            "aarch64-windows",
+            "x86_64-freebsd",
+            "aarch64-freebsd",
+            "x86_64-netbsd",
+            "aarch64-netbsd",
+            "x86_64-aix",
+            "aarch64-aix",
+            "x86_64-solaris",
+            "aarch64-solaris",
+            "x86_64-illumos",
+            "aarch64-illumos",
+            "x86_64-android",
+            "aarch64-android"
+          ],
+          "version": "0.1.0",
+          "buildDeps": [
+            {
+              "name": "cargo_binstall_ghrel"
+            },
+            {
+              "name": "rust_rustup"
+            }
+          ],
+          "moduleSpecifier": "https://raw.githubusercontent.com/metatypedev/ghjk/44d9a41/ports/cargobi.ts"
+        },
+        "crateName": "wit-deps-cli",
+        "locked": true
       },
       "bciqjk5pmo3ffapu7zdpwbzrhcrosd6xu4ov2665j5crfmnl3575igaq": {
         "version": "nightly-2024-05-26",

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
@@ -71,5 +71,4 @@ def deploy():
 
 
 res = deploy()
-# skip:next-line
 print(res.serialized)

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
@@ -1,6 +1,9 @@
 import os
 from os import path
+
+# skip:start
 import sys
+# skip:end
 
 from typegraph.gen.exports.core import MigrationAction
 from typegraph.graph.shared_types import BasicAuth
@@ -32,30 +35,33 @@ def example(g: Graph):
     )
 
 
-# Configure your deployment
+# skip:start
 cwd = sys.argv[1]
 PORT = sys.argv[2]
+# skip:end
 
 
+# Configure your deployment
 def deploy():
-    cwd = os.getcwd()
+    base_url = "<TYPEGATE_URL>"
+    auth = BasicAuth("<USERNAME>", "<PASSWORD>")
 
+    # skip:start
     base_url = f"http://localhost:{PORT}"
     auth = BasicAuth("admin", "password")
+    # skip:end
 
-    config: TypegraphDeployParams = (
-        TypegraphDeployParams(
-            typegate=TypegateConnectionOptions(url=base_url, auth=auth),
-            typegraph_path=os.path.join(cwd, "path-to-typegraph"),
-            prefix="<prefix>",
-            secrets={},
-            migrations_dir=path.join("prisma-migrations", example.name),
-            migration_actions=None,
-            default_migration_action=MigrationAction(
-                apply=True,
-                reset=True,  # allow destructive migrations
-                create=True,
-            ),
+    config: TypegraphDeployParams = TypegraphDeployParams(
+        typegate=TypegateConnectionOptions(url=base_url, auth=auth),
+        typegraph_path=os.path.join(cwd, "path-to-typegraph"),
+        prefix="",
+        secrets={},
+        migrations_dir=path.join("prisma-migrations", example.name),
+        migration_actions=None,
+        default_migration_action=MigrationAction(
+            apply=True,
+            reset=True,  # allow destructive migrations
+            create=True,
         ),
     )
 
@@ -65,3 +71,5 @@ def deploy():
 
 
 res = deploy()
+# skip:next-line
+print(res.serialized)

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
@@ -1,0 +1,67 @@
+import os
+from os import path
+import sys
+
+from typegraph.gen.exports.core import MigrationAction
+from typegraph.graph.shared_types import BasicAuth
+from typegraph.graph.tg_deploy import (
+    TypegraphDeployParams,
+    tg_deploy,
+    TypegateConnectionOptions,
+)
+from typegraph.runtimes.deno import DenoRuntime
+
+from typegraph import Graph, Policy, t, typegraph
+
+# Your typegraph
+
+
+@typegraph()
+def example(g: Graph):
+    deno = DenoRuntime()
+    pub = Policy.public()
+
+    g.expose(
+        pub,
+        sayHello=deno.import_(
+            t.struct({"name": t.string()}),
+            t.string(),
+            module="scripts/say_hello.ts",
+            name="sayHello",
+        ),
+    )
+
+
+# Configure your deployment
+cwd = sys.argv[1]
+PORT = sys.argv[2]
+
+
+def deploy():
+    cwd = os.getcwd()
+
+    base_url = f"http://localhost:{PORT}"
+    auth = BasicAuth("admin", "password")
+
+    config: TypegraphDeployParams = (
+        TypegraphDeployParams(
+            typegate=TypegateConnectionOptions(url=base_url, auth=auth),
+            typegraph_path=os.path.join(cwd, "path-to-typegraph"),
+            prefix="<prefix>",
+            secrets={},
+            migrations_dir=path.join("prisma-migrations", example.name),
+            migration_actions=None,
+            default_migration_action=MigrationAction(
+                apply=True,
+                reset=True,  # allow destructive migrations
+                create=True,
+            ),
+        ),
+    )
+
+    # Deploy to typegate
+    result = tg_deploy(example, config)  # pass your typegraph function name
+    return result
+
+
+res = deploy()

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py
@@ -3,8 +3,8 @@ from os import path
 
 # skip:start
 import sys
-# skip:end
 
+# skip:end
 from typegraph.gen.exports.core import MigrationAction
 from typegraph.graph.shared_types import BasicAuth
 from typegraph.graph.tg_deploy import (
@@ -13,12 +13,10 @@ from typegraph.graph.tg_deploy import (
     TypegateConnectionOptions,
 )
 from typegraph.runtimes.deno import DenoRuntime
-
 from typegraph import Graph, Policy, t, typegraph
 
+
 # Your typegraph
-
-
 @typegraph()
 def example(g: Graph):
     deno = DenoRuntime()
@@ -38,14 +36,13 @@ def example(g: Graph):
 # skip:start
 cwd = sys.argv[1]
 PORT = sys.argv[2]
+
+
 # skip:end
-
-
 # Configure your deployment
 def deploy():
     base_url = "<TYPEGATE_URL>"
     auth = BasicAuth("<USERNAME>", "<PASSWORD>")
-
     # skip:start
     base_url = f"http://localhost:{PORT}"
     auth = BasicAuth("admin", "password")
@@ -70,5 +67,7 @@ def deploy():
     return result
 
 
+# typegate response
 res = deploy()
+# skip:next-line
 print(res.serialized)

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
@@ -1,12 +1,11 @@
+// skip:start
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
+// skip:end
 
 import { Policy, t, typegraph } from "@typegraph/sdk/index.js";
 import { DenoRuntime } from "@typegraph/sdk/runtimes/deno.js";
-// skip:start
 import * as path from "node:path";
-// skip:end
-
 import { BasicAuth, tgDeploy } from "@typegraph/sdk/tg_deploy.js";
 
 // Your typegraph
@@ -24,21 +23,18 @@ export const tg = await typegraph("example", (g) => {
     pub,
   );
 });
-
 // skip:start
 const cwd = Deno.args[0];
 const PORT = Deno.args[1];
 // skip:end
 
 // Configure your deployment
-
 let baseUrl = "<TYPEGATE_URL>";
 let auth = new BasicAuth("<USERNAME>", "<PASSWORD>");
-
 // skip:start
 baseUrl = `http://localhost:${PORT}`;
 auth = new BasicAuth("admin", "password");
-// skip: end
+// skip:end
 
 const config = {
   typegate: {
@@ -57,4 +53,5 @@ const config = {
 
 // Deploy to typegate
 const deployResult = await tgDeploy(tg, config);
+// skip:next-line
 console.log(deployResult);

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
@@ -31,8 +31,13 @@ const PORT = Deno.args[1];
 
 // Configure your deployment
 
-const baseUrl = `http://localhost:${PORT}`;
-const auth = new BasicAuth("admin", "password");
+let baseUrl = "<TYPEGATE_URL>";
+let auth = new BasicAuth("<USERNAME>", "<PASSWORD>");
+
+// skip:start
+baseUrl = `http://localhost:${PORT}`;
+auth = new BasicAuth("admin", "password");
+// skip: end
 
 const config = {
   typegate: {

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
@@ -3,7 +3,9 @@
 
 import { Policy, t, typegraph } from "@typegraph/sdk/index.js";
 import { DenoRuntime } from "@typegraph/sdk/runtimes/deno.js";
-import * as path from "path";
+// skip:start
+import * as path from "node:path";
+// skip:end
 
 import { BasicAuth, tgDeploy } from "@typegraph/sdk/tg_deploy.js";
 
@@ -26,7 +28,6 @@ export const tg = await typegraph("example", (g) => {
 // skip:start
 const cwd = Deno.args[0];
 const PORT = Deno.args[1];
-
 // skip:end
 
 // Configure your deployment
@@ -45,7 +46,7 @@ const config = {
     auth: auth,
   },
   typegraphPath: path.join(cwd, "path-to-typegraph.ts"),
-  prefix: "<prefx>",
+  prefix: "",
   secrets: {},
   migrationsDir: path.join("prisma-migrations", tg.name),
   defaultMigrationAction: {

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts
@@ -1,0 +1,54 @@
+// Copyright Metatype OÜ, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+import { Policy, t, typegraph } from "@typegraph/sdk/index.js";
+import { DenoRuntime } from "@typegraph/sdk/runtimes/deno.js";
+import * as path from "path";
+
+import { BasicAuth, tgDeploy } from "@typegraph/sdk/tg_deploy.js";
+
+// Your typegraph
+export const tg = await typegraph("example", (g) => {
+  const deno = new DenoRuntime();
+  const pub = Policy.public();
+
+  g.expose(
+    {
+      sayHello: deno.import(t.struct({ name: t.string() }), t.string(), {
+        module: "scripts/say_hello.ts",
+        name: "sayHello",
+      }),
+    },
+    pub,
+  );
+});
+
+// skip:start
+const cwd = Deno.args[0];
+const PORT = Deno.args[1];
+
+// skip:end
+
+// Configure your deployment
+
+const baseUrl = `http://localhost:${PORT}`;
+const auth = new BasicAuth("admin", "password");
+
+const config = {
+  typegate: {
+    url: baseUrl,
+    auth: auth,
+  },
+  typegraphPath: path.join(cwd, "path-to-typegraph.ts"),
+  prefix: "<prefx>",
+  secrets: {},
+  migrationsDir: path.join("prisma-migrations", tg.name),
+  defaultMigrationAction: {
+    create: true,
+    reset: true, // allow destructive migrations
+  },
+};
+
+// Deploy to typegate
+const deployResult = await tgDeploy(tg, config);
+console.log(deployResult);

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
@@ -72,7 +72,6 @@ Meta.test(
         console.error("Typegraph Deploy Script Failed: ", deployResult.stderr);
       }
       assertExists(deployResult.stdout, "Typegraph is serialized");
-      console.log(deployResult.stdout);
     });
 
     await t.should("remove typegraph from typegate", async () => {

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
@@ -1,0 +1,91 @@
+// Copyright Metatype OÜ, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+import { Meta } from "test-utils/mod.ts";
+import { MetaTest } from "../../../utils/test.ts";
+import * as path from "std/path/mod.ts";
+
+Meta.test(
+  {
+    name: "Programmatic deployment test - Python SDK",
+  },
+  async (t: MetaTest) => {
+    const port = t.port;
+    const scriptsPath = path.join(t.workingDir, "docs/how-tos/prog_deploy");
+
+    await t.should("deploy python typegraph to typegate", async () => {
+      const pythonDeploy = path.join(scriptsPath, "prog_deploy.py");
+      const deployCommand = [
+        ...(
+          Deno.env.get("MCLI_LOADER_PY")?.split(" ") ??
+            ["python3"]
+        ),
+        pythonDeploy,
+        port,
+        scriptsPath,
+      ];
+      const deployResult = await t.meta(deployCommand);
+      if (deployResult.code !== 0) {
+        console.error("Typegraph Deploy Script Failed: ", deployResult.stderr);
+      }
+    });
+
+    await t.should("remove typegraph from typegate", async () => {
+      const pythonRemove = path.join(scriptsPath, "prog_remove.py");
+      const removeCommand = [
+        "deno",
+        "run",
+        "-A",
+        pythonRemove,
+        scriptsPath,
+        port,
+      ];
+      const removeResult = await t.meta(removeCommand);
+      if (removeResult.code !== 0) {
+        console.error("Typegraph Remove Script Failed: ", removeResult.stderr);
+      }
+    });
+  },
+);
+
+Meta.test(
+  {
+    name: "Programmatic deployment test - TS SDK",
+  },
+  async (t: MetaTest) => {
+    const port = t.port;
+    const scriptsPath = path.join(t.workingDir, "docs/how-tos/prog_deploy");
+
+    await t.should("deploy typegraph to typegate", async () => {
+      const tsDeploy = path.join(scriptsPath, "prog_deploy.ts");
+      const deployCommand = [
+        "deno",
+        "run",
+        "-A",
+        tsDeploy,
+        scriptsPath,
+        port,
+      ];
+      const deployResult = await t.meta(deployCommand);
+      if (deployResult.code !== 0) {
+        console.error("Typegraph Deploy Script Failed: ", deployResult.stderr);
+      }
+    });
+
+    await t.should("remove typegraph from typegate", async () => {
+      const tsRemove = path.join(scriptsPath, "prog_remove.ts");
+      const removeCommand = [
+        "deno",
+        "run",
+        "-A",
+        tsRemove,
+        scriptsPath,
+        port,
+      ];
+      const removeResult = await t.meta(removeCommand);
+      if (removeResult.code !== 0) {
+        console.error("Typegraph Remove Script Failed: ", removeResult.stderr);
+      }
+    });
+  },
+);

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
@@ -4,6 +4,7 @@
 import { Meta } from "test-utils/mod.ts";
 import { MetaTest } from "../../../utils/test.ts";
 import * as path from "std/path/mod.ts";
+import { assertEquals, assertExists } from "std/assert/mod.ts";
 
 Meta.test(
   {
@@ -16,34 +17,35 @@ Meta.test(
     await t.should("deploy python typegraph to typegate", async () => {
       const pythonDeploy = path.join(scriptsPath, "prog_deploy.py");
       const deployCommand = [
-        ...(
-          Deno.env.get("MCLI_LOADER_PY")?.split(" ") ??
-            ["python3"]
-        ),
+        ...(Deno.env.get("MCLI_LOADER_PY")?.split(" ") ?? ["python3"]),
         pythonDeploy,
-        port,
         scriptsPath,
+        port.toString(),
       ];
-      const deployResult = await t.meta(deployCommand);
+      const deployResult = await t.shell(deployCommand);
       if (deployResult.code !== 0) {
         console.error("Typegraph Deploy Script Failed: ", deployResult.stderr);
       }
+
+      assertExists(deployResult.stdout, "Typegraph is serialized");
     });
 
     await t.should("remove typegraph from typegate", async () => {
       const pythonRemove = path.join(scriptsPath, "prog_remove.py");
       const removeCommand = [
-        "deno",
-        "run",
-        "-A",
+        ...(Deno.env.get("MCLI_LOADER_PY")?.split(" ") ?? ["python3"]),
         pythonRemove,
         scriptsPath,
-        port,
+        port.toString(),
       ];
-      const removeResult = await t.meta(removeCommand);
+      const removeResult = await t.shell(removeCommand);
       if (removeResult.code !== 0) {
         console.error("Typegraph Remove Script Failed: ", removeResult.stderr);
       }
+      assertEquals(
+        removeResult.stdout,
+        "{'data': {'removeTypegraphs': True}}\n",
+      );
     });
   },
 );
@@ -64,9 +66,9 @@ Meta.test(
         "-A",
         tsDeploy,
         scriptsPath,
-        port,
+        port.toString(),
       ];
-      const deployResult = await t.meta(deployCommand);
+      const deployResult = await t.shell(deployCommand);
       if (deployResult.code !== 0) {
         console.error("Typegraph Deploy Script Failed: ", deployResult.stderr);
       }
@@ -80,9 +82,9 @@ Meta.test(
         "-A",
         tsRemove,
         scriptsPath,
-        port,
+        port.toString(),
       ];
-      const removeResult = await t.meta(removeCommand);
+      const removeResult = await t.shell(removeCommand);
       if (removeResult.code !== 0) {
         console.error("Typegraph Remove Script Failed: ", removeResult.stderr);
       }

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
@@ -35,7 +35,6 @@ Meta.test(
       const removeCommand = [
         ...(Deno.env.get("MCLI_LOADER_PY")?.split(" ") ?? ["python3"]),
         pythonRemove,
-        scriptsPath,
         port.toString(),
       ];
       const removeResult = await t.shell(removeCommand);
@@ -72,6 +71,8 @@ Meta.test(
       if (deployResult.code !== 0) {
         console.error("Typegraph Deploy Script Failed: ", deployResult.stderr);
       }
+      assertExists(deployResult.stdout, "Typegraph is serialized");
+      console.log(deployResult.stdout);
     });
 
     await t.should("remove typegraph from typegate", async () => {
@@ -81,13 +82,16 @@ Meta.test(
         "run",
         "-A",
         tsRemove,
-        scriptsPath,
         port.toString(),
       ];
       const removeResult = await t.shell(removeCommand);
       if (removeResult.code !== 0) {
         console.error("Typegraph Remove Script Failed: ", removeResult.stderr);
       }
+      assertEquals(
+        removeResult.stdout,
+        "{ data: { removeTypegraphs: true } }\n",
+      );
     });
   },
 );

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_deploy_test.ts
@@ -77,13 +77,7 @@ Meta.test(
 
     await t.should("remove typegraph from typegate", async () => {
       const tsRemove = path.join(scriptsPath, "prog_remove.ts");
-      const removeCommand = [
-        "deno",
-        "run",
-        "-A",
-        tsRemove,
-        port.toString(),
-      ];
+      const removeCommand = ["deno", "run", "-A", tsRemove, port.toString()];
       const removeResult = await t.shell(removeCommand);
       if (removeResult.code !== 0) {
         console.error("Typegraph Remove Script Failed: ", removeResult.stderr);

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
@@ -12,9 +12,8 @@ from typegraph.graph.shared_types import BasicAuth
 import sys
 # skip: end
 
+
 # Your typegraph
-
-
 @typegraph()
 def example(g: Graph):
     # ..
@@ -23,8 +22,7 @@ def example(g: Graph):
 
 
 # skip:start
-# cwd = sys.argv[1]
-PORT = sys.argv[2]
+PORT = sys.argv[1]
 # skip:end
 
 

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
@@ -1,5 +1,4 @@
 # ..
-import sys
 from typegraph.graph.tg_deploy import (
     TypegateConnectionOptions,
     TypegraphRemoveParams,
@@ -9,29 +8,39 @@ from typegraph.graph.tg_deploy import (
 from typegraph import Graph, typegraph
 from typegraph.graph.shared_types import BasicAuth
 
+# skip:start
+import sys
+# skip: end
+
 # Your typegraph
 
 
 @typegraph()
 def example(g: Graph):
     # ..
+    # skip:next-line
     pass
 
 
-PORT = sys.argv[1]
+# skip:start
+# cwd = sys.argv[1]
+PORT = sys.argv[2]
+# skip:end
 
 
 def remove():
     base_url = "<TYPEGATE_URL>"
     auth = BasicAuth("<USERNAME>", "<PASSWORD>")
 
+    # skip:start
     base_url = f"http://localhost:{PORT}"
     auth = BasicAuth("admin", "password")
+    # skip:end
 
     result = tg_remove(
         example,
         params=TypegraphRemoveParams(
-            typegate=TypegateConnectionOptions(url=base_url, auth=auth)
+            typegate=TypegateConnectionOptions(url=base_url, auth=auth),
         ),
     )
 
@@ -41,5 +50,4 @@ def remove():
 res = remove()
 
 # Response from typegate
-
 print(res.typegate)

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
@@ -35,7 +35,7 @@ def remove():
     # skip:end
 
     result = tg_remove(
-        example,
+        example.name,  # pass the typegraph name
         params=TypegraphRemoveParams(
             typegate=TypegateConnectionOptions(url=base_url, auth=auth),
         ),

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
@@ -1,0 +1,45 @@
+# ..
+import sys
+from typegraph.graph.tg_deploy import (
+    TypegateConnectionOptions,
+    TypegraphRemoveParams,
+    tg_remove,
+)
+
+from typegraph import Graph, typegraph
+from typegraph.graph.shared_types import BasicAuth
+
+# Your typegraph
+
+
+@typegraph()
+def example(g: Graph):
+    # ..
+    pass
+
+
+PORT = sys.argv[1]
+
+
+def remove():
+    base_url = "<TYPEGATE_URL>"
+    auth = BasicAuth("<USERNAME>", "<PASSWORD>")
+
+    base_url = f"http://localhost:{PORT}"
+    auth = BasicAuth("admin", "password")
+
+    result = tg_remove(
+        example,
+        params=TypegraphRemoveParams(
+            typegate=TypegateConnectionOptions(url=base_url, auth=auth)
+        ),
+    )
+
+    return result
+
+
+res = remove()
+
+# Response from typegate
+
+print(res.typegate)

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.py
@@ -10,7 +10,7 @@ from typegraph.graph.shared_types import BasicAuth
 
 # skip:start
 import sys
-# skip: end
+# skip:end
 
 
 # Your typegraph
@@ -23,13 +23,12 @@ def example(g: Graph):
 
 # skip:start
 PORT = sys.argv[1]
+
+
 # skip:end
-
-
 def remove():
     base_url = "<TYPEGATE_URL>"
     auth = BasicAuth("<USERNAME>", "<PASSWORD>")
-
     # skip:start
     base_url = f"http://localhost:{PORT}"
     auth = BasicAuth("admin", "password")
@@ -45,7 +44,7 @@ def remove():
     return result
 
 
-res = remove()
-
 # Response from typegate
+res = remove()
+# skip:next-line
 print(res.typegate)

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
@@ -1,8 +1,9 @@
+// skip:start
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
+// skip:end
 
 import { typegraph } from "@typegraph/sdk/index.js";
-
 import { BasicAuth, tgRemove } from "@typegraph/sdk/tg_deploy.js";
 
 // Your typegraph
@@ -16,6 +17,7 @@ const baseUrl = `http://localhost:${PORT}`;
 const auth = new BasicAuth("admin", "password");
 // skip:end
 
+// Response from typegate
 const result = await tgRemove(tg, {
   typegate: {
     url: baseUrl,
@@ -23,5 +25,5 @@ const result = await tgRemove(tg, {
   },
 });
 
-// Response from typegate
+// skip:next-line
 console.log(result.typegate);

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
@@ -17,8 +17,8 @@ const baseUrl = `http://localhost:${PORT}`;
 const auth = new BasicAuth("admin", "password");
 // skip:end
 
-// Response from typegate
-const result = await tgRemove(tg, {
+// Response from typegate,
+const result = await tgRemove(tg.name, { // pass the typegraph name
   typegate: {
     url: baseUrl,
     auth: auth,

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
@@ -1,0 +1,58 @@
+// Copyright Metatype OÜ, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+import { Policy, t, typegraph } from "@typegraph/sdk/index.js";
+import { DenoRuntime } from "@typegraph/sdk/runtimes/deno.js";
+// import * as path from "path";
+
+import { BasicAuth, tgRemove } from "@typegraph/sdk/tg_deploy.js";
+
+// Your typegraph
+const tg = await typegraph("example", (g) => {
+  const deno = new DenoRuntime();
+  const pub = Policy.public();
+
+  g.expose(
+    {
+      sayHello: deno.import(t.struct({ name: t.string() }), t.string(), {
+        module: "path/to/say_hello.ts",
+        name: "sayHello",
+      }),
+    },
+    pub,
+  );
+});
+
+const PORT = Deno.args[0];
+
+// Configure your deployment
+
+const baseUrl = `http://localhost:${PORT}`;
+const auth = new BasicAuth("admin", "password");
+
+// const config = {
+//   typegate: {
+//     url: baseUrl,
+//     auth: auth,
+//   },
+//   typegraphPath: "./deploy.mjs",
+//   prefix: "<prefx>",
+//   secrets: {},
+//   migrationsDir: path.join("prisma-migrations", tg.name),
+//   defaultMigrationAction: {
+//     create: true,
+//     reset: true, // allow destructive migrations
+//   },
+// };
+
+// Deploy to typegate
+// const deployResult = await tgDeploy(tg, config);
+// console.log(deployResult);
+
+const { typegate } = await tgRemove(tg, {
+  url: baseUrl,
+  auth: auth,
+});
+
+// Response from typegate
+console.log(typegate);

--- a/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts
@@ -1,58 +1,27 @@
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
-import { Policy, t, typegraph } from "@typegraph/sdk/index.js";
-import { DenoRuntime } from "@typegraph/sdk/runtimes/deno.js";
-// import * as path from "path";
+import { typegraph } from "@typegraph/sdk/index.js";
 
 import { BasicAuth, tgRemove } from "@typegraph/sdk/tg_deploy.js";
 
 // Your typegraph
-const tg = await typegraph("example", (g) => {
-  const deno = new DenoRuntime();
-  const pub = Policy.public();
-
-  g.expose(
-    {
-      sayHello: deno.import(t.struct({ name: t.string() }), t.string(), {
-        module: "path/to/say_hello.ts",
-        name: "sayHello",
-      }),
-    },
-    pub,
-  );
+const tg = await typegraph("example", (_g) => {
+  // ...
 });
 
+// skip:start
 const PORT = Deno.args[0];
-
-// Configure your deployment
-
 const baseUrl = `http://localhost:${PORT}`;
 const auth = new BasicAuth("admin", "password");
+// skip:end
 
-// const config = {
-//   typegate: {
-//     url: baseUrl,
-//     auth: auth,
-//   },
-//   typegraphPath: "./deploy.mjs",
-//   prefix: "<prefx>",
-//   secrets: {},
-//   migrationsDir: path.join("prisma-migrations", tg.name),
-//   defaultMigrationAction: {
-//     create: true,
-//     reset: true, // allow destructive migrations
-//   },
-// };
-
-// Deploy to typegate
-// const deployResult = await tgDeploy(tg, config);
-// console.log(deployResult);
-
-const { typegate } = await tgRemove(tg, {
-  url: baseUrl,
-  auth: auth,
+const result = await tgRemove(tg, {
+  typegate: {
+    url: baseUrl,
+    auth: auth,
+  },
 });
 
 // Response from typegate
-console.log(typegate);
+console.log(result.typegate);

--- a/typegate/tests/docs/how-tos/prog_deploy/scripts/say_hello.ts
+++ b/typegate/tests/docs/how-tos/prog_deploy/scripts/say_hello.ts
@@ -1,0 +1,6 @@
+// Copyright Metatype OÜ, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+export function sayHello() {
+  return "Hell0";
+}

--- a/typegate/tests/e2e/self_deploy/self_deploy_test.ts
+++ b/typegate/tests/e2e/self_deploy/self_deploy_test.ts
@@ -36,7 +36,8 @@ Meta.test(
       migrations: [],
     });
 
-    const { typegate: gateResponseRem } = await tgRemove(tg, {
+    // pass the typegraph name
+    const { typegate: gateResponseRem } = await tgRemove(tg.name, {
       typegate: { url: gate, auth },
     });
     assertEquals(gateResponseRem, { data: { removeTypegraphs: true } });

--- a/typegate/tests/utils/test.ts
+++ b/typegate/tests/utils/test.ts
@@ -382,7 +382,7 @@ export class MetaTest {
   }
 }
 
-function extractJsonFromStdout(stdout: string): string | null {
+export function extractJsonFromStdout(stdout: string): string | null {
   let jsonStart = null;
   let inJson = false;
 

--- a/typegate/tests/utils/test.ts
+++ b/typegate/tests/utils/test.ts
@@ -382,7 +382,7 @@ export class MetaTest {
   }
 }
 
-export function extractJsonFromStdout(stdout: string): string | null {
+function extractJsonFromStdout(stdout: string): string | null {
   let jsonStart = null;
   let inJson = false;
 

--- a/typegraph/node/sdk/src/tg_deploy.ts
+++ b/typegraph/node/sdk/src/tg_deploy.ts
@@ -130,7 +130,7 @@ export async function tgDeploy(
 }
 
 export async function tgRemove(
-  typegraph: TypegraphOutput,
+  typegraphName: string,
   params: TypegraphRemoveParams,
 ): Promise<RemoveResult> {
   const { url, auth } = params.typegate;
@@ -146,9 +146,9 @@ export async function tgRemove(
     {
       method: "POST",
       headers,
-      body: wit_utils.gqlRemoveQuery([typegraph.name]),
+      body: wit_utils.gqlRemoveQuery([typegraphName.toString()]),
     },
-    `tgRemove failed to remove typegraph ${typegraph.name}`,
+    `tgRemove failed to remove typegraph ${typegraphName}`,
   );
 
   return { typegate: response };

--- a/typegraph/python/typegraph/graph/tg_deploy.py
+++ b/typegraph/python/typegraph/graph/tg_deploy.py
@@ -129,7 +129,7 @@ def tg_deploy(tg: TypegraphOutput, params: TypegraphDeployParams) -> DeployResul
     )
 
 
-def tg_remove(tg: TypegraphOutput, params: TypegraphRemoveParams):
+def tg_remove(typegraph_name: str, params: TypegraphRemoveParams):
     typegate = params.typegate
 
     sep = "/" if not typegate.url.endswith("/") else ""
@@ -139,7 +139,7 @@ def tg_remove(tg: TypegraphOutput, params: TypegraphRemoveParams):
     if typegate.auth is not None:
         headers["Authorization"] = typegate.auth.as_header_value()
 
-    res = wit_utils.gql_remove_query(store, [tg.name])
+    res = wit_utils.gql_remove_query(store, [typegraph_name])
 
     if isinstance(res, Err):
         raise Exception(res.value)

--- a/website/blog/2024-05-09-programmatic-deployment/index.mdx
+++ b/website/blog/2024-05-09-programmatic-deployment/index.mdx
@@ -46,49 +46,38 @@ It's the place where you tell which typegate you want to deploy to, how you want
     <TabItem value="python">
 
 ```python
-config_params = MigrationConfig(
-    migration_dir= "path/to/prisma-migrations",
-    global_action=MigrationAction(
-        create=True, # allow creating migrations
-        reset=True  # allow destructive migrations
-    ),
-    runtime_actions=None,
-)
-artifacts_config = ArtifactResolutionConfig(
-    prisma_migration=config_params,
-    prefix=None,
-    dir=None,  # artifacts are resolved relative to this path
-    disable_artifact_resolution=None,
-    codegen=None,
-)
-config = TypegraphDeployParams(
-    base_url="<TYPEGATE_URL>",
-    auth=BasicAuth(username="<USERNAME>", password="<PASSWORD>"),
-    artifacts_config=artifacts_config,
-    secrets={"POSTGRES": "<DB_URL>"},
-)
+config: TypegraphDeployParams = TypegraphDeployParams(
+        typegate=TypegateConnectionOptions(url="<TYPEGATE_URL>", auth=BasicAuth("<USERNAME>", "<PASSWORD>")),
+        typegraph_path=os.path.join(cwd, "path-to-typegraph"),
+        prefix="",
+        secrets={},
+        migrations_dir=path.join("prisma-migrations", example.name),
+        migration_actions=None,
+        default_migration_action=MigrationAction(
+            apply=True,
+            reset=True,  # allow destructive migrations
+            create=True,
+        ),
+    )
 ```
 
     </TabItem>
     <TabItem value="typescript">
 
 ```typescript
-const artifactsConfig = {
-  prismaMigration: {
-    globalAction: {
-      create: true, // allow creating migrations
-      reset: true, // allow destructive migrations
-    },
-    migrationDir: "path/to/prisma-migrations",
-  },
-  dir: ".", // artifacts are resolved relative to this path
-};
-
 const config = {
-  baseUrl: "<TYPEGATE_URL>",
-  auth: new BasicAuth("<USERNAME>", "<PASSWORD>"),
+  typegate: {
+    url: "<TYPEGATE_URL>",
+    auth: new BasicAuth("<USERNAME>", "<PASSWORD>"),
+  },
+  typegraphPath: path.join(cwd, "path-to-typegraph.ts"),
+  prefix: "",
   secrets: { POSTGRES: "<DB_URL>" },
-  artifactsConfig,
+  migrationsDir: path.join("prisma-migrations", tg.name),
+  defaultMigrationAction: {
+    create: true,
+    reset: true, // allow destructive migrations
+  },
 };
 ```
 
@@ -102,7 +91,7 @@ Now, picture this, you have a lot of typegraphs and one or more typegate instanc
 
 ```typescript
 // ..
-import { tgDeploy, tgRemove } from "@typegraph/sdk/tg_deploy";
+import { tgDeploy, tgRemove } from "@typegraph/sdk/tg_deploy.js";
 // ..
 
 const BASIC_AUTH = loadMyAuthsFromSomeSource();
@@ -127,19 +116,18 @@ export function getConfig(tgName: string, tgLocation: string) {
   // Note: You can always develop various ways of constructing the configuration,
   // like loading it from a file.
   return {
-    baseUrl: TYPEGATE_URL,
-    auth: BASIC_AUTH,
-    secrets: {
-      /* .. */
+    typegate: {
+      url: "<TYPEGATE_URL>",
+      auth: new BasicAuth("<USERNAME>", "<PASSWORD>"),
     },
-    artifactsConfig: {
-      prismaMigration: {
-        // ..
-        // convention used by meta-cli but you are free to do whatever you want
-        migrationDir: "prisma-migrations/" + tgName,
-      },
+    typegraphPath: path.join(cwd, "path-to-typegraph.ts"),
+    prefix: "",
+    secrets: { POSTGRES: "<DB_URL>" },
+    migrationsDir: path.join("prisma-migrations", tg.name),
+    defaultMigrationAction: {
+      create: true,
+      reset: true, // allow destructive migrations
     },
-    typegraphPath: tgLocation,
   };
 }
 
@@ -169,7 +157,7 @@ export async function undeployAll() {
   for (const { tg } of typegraphs) {
     try {
       // use tgRemove to remove typegraphs
-      const { typegate } = await tgRemove(tg, {
+      const { typegate } = await tgRemove("<TYPEGRAPH_NAME>", {
         baseUrl: TYPEGATE_URL,
         auth: BASIC_AUTH,
       });

--- a/website/docs/guides/programmatic-deployment/index.mdx
+++ b/website/docs/guides/programmatic-deployment/index.mdx
@@ -1,5 +1,6 @@
 import SDKTabs from "@site/src/components/SDKTabs";
 import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
 
 # Programmatic deployment
 
@@ -18,7 +19,11 @@ You are required to provide the configurations and also handle migrations by you
 <SDKTabs>
     <TabItem value="python">
 
-```python
+    <CodeBlock language="python">
+  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py").content}
+    </CodeBlock>
+
+{/* ```python
 import os
 from os import path
 
@@ -77,12 +82,16 @@ def deploy():
     return result
 
 res = deploy()
-```
+``` */}
 
     </TabItem>
     <TabItem value="typescript">
 
-```typescript
+    <CodeBlock language="typescript">
+  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts").content}
+    </CodeBlock>
+
+{/* ```typescript
 import { Policy, t, typegraph } from "@typegraph/sdk/index.js";
 import { DenoRuntime } from "@typegraph/sdk/runtimes/deno.js";
 import * as path from "path";
@@ -125,7 +134,7 @@ const config = {
 
 // Deploy to typegate
 const deployResult = await tgDeploy(tg, config);
-```
+``` */}
 
     </TabItem>
 

--- a/website/docs/guides/programmatic-deployment/index.mdx
+++ b/website/docs/guides/programmatic-deployment/index.mdx
@@ -23,118 +23,12 @@ You are required to provide the configurations and also handle migrations by you
   {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py").content}
     </CodeBlock>
 
-{/* ```python
-import os
-from os import path
-
-from typegraph.gen.exports.core import MigrationAction
-from typegraph.graph.shared_types import BasicAuth
-from typegraph.graph.tg_deploy import (
-    TypegraphDeployParams,
-    tg_deploy,
-    TypegateConnectionOptions,
-)
-from typegraph.runtimes.deno import DenoRuntime
-
-from typegraph import Graph, Policy, t, typegraph
-
-# Your typegraph
-
-@typegraph()
-def example(g: Graph):
-    deno = DenoRuntime()
-    pub = Policy.public()
-
-    g.expose(
-        pub,
-        sayHello=deno.import_(
-            t.struct({"name": t.string()}),
-            t.string(),
-            module="path/to/say_hello.ts",
-            name="sayHello",
-        ),
-    )
-
-# Configure your deployment
-
-def deploy():
-    cwd = os.getcwd()
-
-    config: TypegraphDeployParams = TypegraphDeployParams(
-            typegate=TypegateConnectionOptions(
-                url="<TYPEGATE_URL>",
-                auth=BasicAuth("<USERNAME>", "<PASSWORD>")
-            ),
-            typegraph_path=os.path.join(cwd, "path/to/typegraph"),
-            prefix="<prefix>",
-            secrets={},
-            migrations_dir=path.join("prisma-migrations", example.name),
-            migration_actions=None,
-            default_migration_action=MigrationAction(
-                apply=True,
-                reset=True, # allow destructive migrations
-                create=True
-            ),
-        ),
-
-    # Deploy to typegate
-    result = tg_deploy(example, config) # pass your typegraph function name
-    return result
-
-res = deploy()
-``` */}
-
     </TabItem>
     <TabItem value="typescript">
 
     <CodeBlock language="typescript">
   {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts").content}
     </CodeBlock>
-
-{/* ```typescript
-import { Policy, t, typegraph } from "@typegraph/sdk/index.js";
-import { DenoRuntime } from "@typegraph/sdk/runtimes/deno.js";
-import * as path from "path";
-
-import { wit_utils } from "@typegraph/sdk/wit.js";
-import { BasicAuth, tgDeploy } from "@typegraph/sdk/tg_deploy.js";
-
-// Your typegraph
-const tg = await typegraph("example", (g) => {
-  const deno = new DenoRuntime();
-  const pub = Policy.public();
-
-  g.expose(
-    {
-      sayHello: deno.import(t.struct({ name: t.string() }), t.string(), {
-        module: "path/to/say_hello.ts",
-        name: "sayHello",
-      }),
-    },
-    pub,
-  );
-});
-
-// Configure your deployment
-
-const config = {
-  typegate: {
-    url: "<TYPEGATE_URL>",
-    auth: new BasicAuth("<USERNAME>", "<PASSWORD>"),
-  },
-  typegraphPath: "<absolute/path/to/typegraph>",
-  prefix: "<prefx>",
-  secrets: {},
-  migrationsDir: path.join("prisma-migrations", tg.name),
-  defaultMigrationAction: {
-    create: true,
-    reset: true, // allow destructive migrations
-  },
-};
-
-// Deploy to typegate
-const deployResult = await tgDeploy(tg, config);
-``` */}
 
     </TabItem>
 

--- a/website/docs/guides/programmatic-deployment/index.mdx
+++ b/website/docs/guides/programmatic-deployment/index.mdx
@@ -22,6 +22,7 @@ You are required to provide the configurations and also handle migrations by you
     <CodeBlock language="python">
 
 {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py").content}
+
 </CodeBlock>
 
     </TabItem>
@@ -30,6 +31,7 @@ You are required to provide the configurations and also handle migrations by you
     <CodeBlock language="typescript">
 
 {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts").content}
+
 </CodeBlock>
 
     </TabItem>
@@ -46,6 +48,7 @@ Similarly to the above, you can undeploy typegraphs using the `tgRemove`/`tg_rem
     <CodeBlock language="python">
 
 {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.py").content}
+
 </CodeBlock>
 
     </TabItem>
@@ -54,6 +57,7 @@ Similarly to the above, you can undeploy typegraphs using the `tgRemove`/`tg_rem
       <CodeBlock language="typescript">
 
 {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts").content}
+
 </CodeBlock>
 
     </TabItem>

--- a/website/docs/guides/programmatic-deployment/index.mdx
+++ b/website/docs/guides/programmatic-deployment/index.mdx
@@ -20,15 +20,17 @@ You are required to provide the configurations and also handle migrations by you
     <TabItem value="python">
 
     <CodeBlock language="python">
-  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py").content}
-    </CodeBlock>
+
+{require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.py").content}
+</CodeBlock>
 
     </TabItem>
     <TabItem value="typescript">
 
     <CodeBlock language="typescript">
-  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts").content}
-    </CodeBlock>
+
+{require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_deploy.ts").content}
+</CodeBlock>
 
     </TabItem>
 
@@ -42,15 +44,17 @@ Similarly to the above, you can undeploy typegraphs using the `tgRemove`/`tg_rem
     <TabItem value="python">
 
     <CodeBlock language="python">
-  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.py").content}
-    </CodeBlock>
+
+{require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.py").content}
+</CodeBlock>
 
     </TabItem>
     <TabItem value="typescript">
 
       <CodeBlock language="typescript">
-  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts").content}
-      </CodeBlock>
+
+{require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts").content}
+</CodeBlock>
 
     </TabItem>
 

--- a/website/docs/guides/programmatic-deployment/index.mdx
+++ b/website/docs/guides/programmatic-deployment/index.mdx
@@ -41,62 +41,16 @@ Similarly to the above, you can undeploy typegraphs using the `tgRemove`/`tg_rem
 <SDKTabs>
     <TabItem value="python">
 
-```python
-# ..
-from typegraph.graph.tg_deploy import (
-    TypegateConnectionOptions,
-    TypegraphDeployParams,
-    TypegraphRemoveParams,
-    tg_remove,
-)
-
-# Your typegraph
-
-@typegraph()
-def example(g: Graph):
-    # ..
-
-def remove():
-    result = tg_remove(
-        example,
-        params=TypegraphRemoveParams(
-            typegate=TypegateConnectionOptions(
-                url = "<TYPEGATE_URL>",
-                auth = BasicAuth("<USERNAME>", "<PASSWORD>")
-            )
-        )
-    )
-
-    return result
-
-res = remove()
-
-# Response from typegate
-
-print(res.typegate)
-
-```
+    <CodeBlock language="python">
+  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.py").content}
+    </CodeBlock>
 
     </TabItem>
     <TabItem value="typescript">
 
-```typescript
-// ..
-import { BasicAuth, tgRemove } from "@typegraph/sdk/tg_deploy.js";
-
-// Your typegraph
-const tg = await typegraph("example", (g) => {
-  // ..
-});
-
-const { typegate } = await tgRemove(tg, {
-  url: "<TYPEGATE_URL>",
-  auth: new BasicAuth("<USERNAME>", "<PASSWORD>"),
-});
-
-// Response from typegate
-console.log(typegate);
-```
+      <CodeBlock language="typescript">
+  {require("!!code-loader!../../../../typegate/tests/docs/how-tos/prog_deploy/prog_remove.ts").content}
+      </CodeBlock>
 
     </TabItem>
 


### PR DESCRIPTION
## Add Programmatic deploy tests for the docs

- [x] Add programmatic typegraph deploy/remove tests
- [x] refactor tg_remove to accept `typegraph_name` instead of `TypegraphOutput` obj.

<!-- 1. Explain WHAT the change is about -->

[MET-591](https://linear.app/metatypedev/issue/MET-591/docstest-test-example-script-for-tg-deploy)

<!-- 2. Explain WHY the change cannot be made simpler -->

-

<!-- 3. Explain HOW users should update their code -->

#### Migration notes

_No Migrations Needed_

...

- [x] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [x] End-user documentation is updated to reflect the change
