### PR TITLE
chore: bump to version 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "meta-cli"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "actix",
  "actix-web",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "metagen"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "color-eyre",
  "common",
@@ -7031,7 +7031,7 @@ dependencies = [
 
 [[package]]
 name = "mt_deno"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "deno",
@@ -12139,7 +12139,7 @@ dependencies = [
 
 [[package]]
 name = "typegate"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "colored",
  "env_logger 0.11.0",
@@ -12152,7 +12152,7 @@ dependencies = [
 
 [[package]]
 name = "typegate_engine"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12192,7 +12192,7 @@ dependencies = [
 
 [[package]]
 name = "typegraph_core"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "color-eyre",
@@ -13881,7 +13881,7 @@ checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xtask"
-version = "0.4.4-0"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "libs/pyrt_wit_wire",
 ]
 [workspace.package] 
-version = "0.4.4-0"
+version = "0.4.4"
 edition = "2021"
 
 [workspace.dependencies]

--- a/dev/consts.ts
+++ b/dev/consts.ts
@@ -9,8 +9,8 @@ export const WASMTIME_VERSION = "21.0.0";
 export const WASMTIME_PY_VERSION = "21.0.0";
 export const TYPEGRAPH_VERSION = "0.0.3";
 export const PRISMA_VERSION = "5.6.0";
-export const METATYPE_VERSION = "0.4.4-0";
-export const PUBLISHED_VERSION = "0.4.3";
+export const METATYPE_VERSION = "0.4.4";
+export const PUBLISHED_VERSION = "0.4.4";
 export const SDK_PACKAGE_NAME_TS = "@typegraph/sdk";
 export const TAGLINE =
   `Declarative API development platform. Build backend components with WASM, Typescript and Python, no matter where and how your (legacy) systems are.`;

--- a/dev/tasks-lock.ts
+++ b/dev/tasks-lock.ts
@@ -43,7 +43,7 @@ const tasks: Record<string, DenoTaskDefArgs> = {
         // we don't use the `generate-lockfile` command because
         // "If the lockfile already exists, it will be rebuilt with the
         // latest available version of every package."
-        await $`cargo verify-project`.stdout("piped");
+        await $`cargo tree`.stdout("piped");
       }
     },
   },

--- a/examples/templates/deno/api/example.ts
+++ b/examples/templates/deno/api/example.ts
@@ -1,6 +1,6 @@
-import { Policy, t, typegraph } from "npm:@typegraph/sdk@0.4.3/index";
-import { PythonRuntime } from "npm:@typegraph/sdk@0.4.3/runtimes/python";
-import { DenoRuntime } from "npm:@typegraph/sdk@0.4.3/runtimes/deno";
+import { Policy, t, typegraph } from "npm:@typegraph/sdk@0.4.4/index";
+import { PythonRuntime } from "npm:@typegraph/sdk@0.4.4/runtimes/python";
+import { DenoRuntime } from "npm:@typegraph/sdk@0.4.4/runtimes/deno";
 
 await typegraph("example", (g) => {
   const pub = Policy.public();

--- a/examples/templates/deno/compose.yml
+++ b/examples/templates/deno/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.4.3
+    image: ghcr.io/metatypedev/typegate:v0.4.4
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/compose.yml
+++ b/examples/templates/node/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.4.3
+    image: ghcr.io/metatypedev/typegate:v0.4.4
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/package.json
+++ b/examples/templates/node/package.json
@@ -6,7 +6,7 @@
     "dev": "MCLI_LOADER_CMD='npm x tsx' meta dev"
   },
   "dependencies": {
-    "@typegraph/sdk": "^0.4.3"
+    "@typegraph/sdk": "^0.4.4"
   },
   "devDependencies": {
     "tsx": "^3.13.0",

--- a/examples/templates/python/compose.yml
+++ b/examples/templates/python/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.4.3
+    image: ghcr.io/metatypedev/typegate:v0.4.4
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/python/pyproject.toml
+++ b/examples/templates/python/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "example"
-version = "0.4.4-0"
+version = "0.4.4"
 description = ""
 authors = []
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-typegraph = "0.4.3"
+typegraph = "0.4.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/libs/common/Cargo.toml
+++ b/libs/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.4.4-0"
+version = "0.4.4"
 edition = "2021"
 
 [dependencies]

--- a/libs/metagen/tests/mat_rust/Cargo.toml
+++ b/libs/metagen/tests/mat_rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mat_rust"
 edition = "2021"
-version = "0.4.4-0"
+version = "0.4.4"
 
 [workspace]
 members = ["gen"]

--- a/libs/pyrt_wit_wire/pyproject.toml
+++ b/libs/pyrt_wit_wire/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrt_wit_wire"
-version = "0.4.4-0"
+version = "0.4.4"
 description = "Wasm component implementing the PythonRuntime host using wit_wire protocol."
 license = "Elastic-2.0"
 readme = "README.md"

--- a/libs/xtask/Cargo.toml
+++ b/libs/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.4.4-0"
+version = "0.4.4"
 edition = "2021"
 
 [dependencies]

--- a/meta-cli/Cargo.toml
+++ b/meta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meta-cli"
-version = "0.4.4-0"
+version = "0.4.4"
 edition = "2021"
 
 description = "Declarative API development platform. Build backend components with WASM, Typescript and Python, no matter where and how your (legacy) systems are."

--- a/meta-lsp/package.json
+++ b/meta-lsp/package.json
@@ -4,7 +4,7 @@
   "description": "VSCode extension for Metatype support",
   "icon": "logo.png",
   "author": "Metatype Team",
-  "version": "0.4.4-0",
+  "version": "0.4.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/meta-lsp/ts-language-server/package.json
+++ b/meta-lsp/ts-language-server/package.json
@@ -2,7 +2,7 @@
   "name": "typegraph-ts-server",
   "description": "TypeScript language server for TypeGraph",
   "author": "Metatype Team",
-  "version": "0.4.4-0",
+  "version": "0.4.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/meta-lsp/vscode-metatype-support/package.json
+++ b/meta-lsp/vscode-metatype-support/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-metatype-support",
   "description": "VSCode extension for Metatype support",
   "author": "Metatype Team",
-  "version": "0.4.4-0",
+  "version": "0.4.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metatype"
-version = "0.4.4-0"
+version = "0.4.4"
 description = ""
 authors = []
 

--- a/typegate/src/runtimes/wit_wire/mod.ts
+++ b/typegate/src/runtimes/wit_wire/mod.ts
@@ -9,7 +9,7 @@ import { getLogger } from "../../log.ts";
 
 const logger = getLogger(import.meta);
 
-const METATYPE_VERSION = "0.4.4-0";
+const METATYPE_VERSION = "0.4.4";
 
 export class WitWireMessenger {
   static async init(

--- a/typegate/tests/e2e/upgrade/upgrade_test.ts
+++ b/typegate/tests/e2e/upgrade/upgrade_test.ts
@@ -15,7 +15,7 @@ import { transformSyncConfig } from "@typegate/config.ts";
 import { clearSyncData, setupSync } from "test-utils/hooks.ts";
 import { assertEquals } from "std/assert/assert_equals.ts";
 
-const PUBLISHED_VERSION = "0.4.3";
+const PUBLISHED_VERSION = "0.4.4";
 
 const previousVersion = PUBLISHED_VERSION;
 

--- a/typegate/tests/metagen/__snapshots__/metagen_test.ts.snap
+++ b/typegate/tests/metagen/__snapshots__/metagen_test.ts.snap
@@ -362,7 +362,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.4.4-0";
+        static MT_VERSION: &str = "0.4.4";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }
@@ -1106,7 +1106,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.4.4-0";
+        static MT_VERSION: &str = "0.4.4";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }

--- a/typegate/tests/runtimes/wasm_reflected/rust/Cargo.toml
+++ b/typegate/tests/runtimes/wasm_reflected/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust"
-version = "0.4.4-0"
+version = "0.4.4"
 edition = "2021"
 
 [lib]

--- a/typegraph/core/Cargo.toml
+++ b/typegraph/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typegraph_core"
-version = "0.4.4-0"
+version = "0.4.4"
 edition = "2021"
 
 [lib]

--- a/typegraph/core/src/global_store.rs
+++ b/typegraph/core/src/global_store.rs
@@ -102,7 +102,7 @@ const PREDEFINED_DENO_FUNCTIONS: &[&str] = &["identity", "true"];
 
 thread_local! {
     pub static STORE: RefCell<Store> = RefCell::new(Store::new());
-    pub static SDK_VERSION: String = "0.4.4-0".to_owned();
+    pub static SDK_VERSION: String = "0.4.4".to_owned();
 }
 
 fn with_store<T, F: FnOnce(&Store) -> T>(f: F) -> T {

--- a/typegraph/python/pyproject.toml
+++ b/typegraph/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typegraph"
-version = "0.4.4-0"
+version = "0.4.4"
 description = "Declarative API development platform. Build backend components with WASM, Typescript and Python, no matter where and how your (legacy) systems are."
 authors = ["Metatype Contributors <support@metatype.dev>"]
 license = "MPL-2.0"

--- a/typegraph/python/typegraph/__init__.py
+++ b/typegraph/python/typegraph/__init__.py
@@ -5,4 +5,4 @@ from typegraph.graph.typegraph import typegraph, Graph  # noqa
 from typegraph.policy import Policy  # noqa
 from typegraph import effects as fx  # noqa
 
-version = "0.4.4-0"
+version = "0.4.4"


### PR DESCRIPTION
Prepare release of the 0.4.4 version.

#### Migration notes

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
