### PR TITLE
feat(cli)!: configurable backoff

### DIFF
--- a/meta-cli/src/cli/dev.rs
+++ b/meta-cli/src/cli/dev.rs
@@ -22,7 +22,7 @@ pub struct Dev {
     run_destructive_migrations: bool,
 
     #[clap(long)]
-    max_parallel_loads: Option<usize>,
+    threads: Option<usize>,
 
     /// secrets overload
     #[clap(long = "secret")]
@@ -32,6 +32,14 @@ pub struct Dev {
     /// Do not run a typegate. By default a typegate is run with the current target configuration
     #[clap(long)]
     no_typegate: bool,
+
+    /// max retry count
+    #[clap(long)]
+    retry: Option<usize>,
+
+    /// initial retry interval
+    #[clap(long)]
+    retry_interval_ms: Option<u64>,
 }
 
 #[async_trait]
@@ -48,6 +56,9 @@ impl Action for Dev {
             secrets: self.secrets.clone(),
             #[cfg(feature = "typegate")]
             run_typegate: !self.no_typegate,
+            threads: self.threads,
+            retry: self.retry,
+            retry_interval_ms: self.retry_interval_ms,
         };
 
         let deploy = DeploySubcommand::new(
@@ -55,7 +66,6 @@ impl Action for Dev {
             self.target.clone().unwrap_or("dev".to_string()),
             options,
             None,
-            self.max_parallel_loads,
         );
         deploy.run(args).await
     }


### PR DESCRIPTION
<!--
Pull requests are squashed and merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog.
-->

<!-- 1. Explain WHAT the change is about -->

- Make the backoff configurable through the `--retry` and `--retry-interval-ms` options.
- The default max retry count is changed to 0 on the default mode, and remains 3 on the watch mode.
- The `--max-parallel-loads` option has been renamed to `--threads`.

<!-- 2. Explain WHY the change cannot be made simpler -->



<!-- 3. Explain HOW users should update their code -->

#### Migration notes

The `--max-parallel-loads` option has been renamed to `--threads`.

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [x] End-user documentation is updated to reflect the change
