### PR TITLE
fix: `wasm_backtrace` config bug

### DIFF
--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -1270,126 +1270,144 @@
             "version-bump": {
               "ty": "denoFile@v1",
               "key": "version-bump",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "version-print": {
               "ty": "denoFile@v1",
               "key": "version-print",
               "desc": "Print $METATYPE_VERSION",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "test-lsp": {
               "ty": "denoFile@v1",
               "key": "test-lsp",
-              "envKey": "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy"
+              "envKey": "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq"
             },
             "test-rust": {
               "ty": "denoFile@v1",
               "key": "test-rust",
-              "envKey": "bciqi3e7xmx27tdbvjwwwmh3tetevp3apldch7ifbpauxsovl4cohudq"
+              "envKey": "bciqov4rontailrkkhq4mmg6unksfithoszn3abi3pyfqnvlh6ynkvka"
             },
             "test-website": {
               "ty": "denoFile@v1",
               "key": "test-website",
               "workingDir": "./website",
-              "envKey": "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy"
+              "envKey": "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq"
             },
             "test-e2e": {
               "ty": "denoFile@v1",
               "key": "test-e2e",
               "desc": "Shorthand for `dev/test.ts`",
-              "envKey": "bciqcwkq6wg63c6swnk5bcpk6svhd35mptdi5dzdv6vxb75zc7ooq24i"
+              "envKey": "bciqdyc67uwyl5pkoaaohvgmnpdtuamame6zvktiegfai562fuw5oiiq"
             },
             "lock-sed": {
               "ty": "denoFile@v1",
               "key": "lock-sed",
               "desc": "Update versions",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "lint-udeps": {
               "ty": "denoFile@v1",
               "key": "lint-udeps",
               "desc": "Check for unused cargo depenencies",
-              "envKey": "bciqkoolzb5k3ydzj3hahandxkfaxljpgidgdi6hpvrwxwal3ahmpi6y"
+              "envKey": "bciqgbrnhfvvtmoua3evkupx3f7tt6ma45tpnjsoh5lw5y2igquul76y"
             },
             "install-wasi-adapter": {
               "ty": "denoFile@v1",
               "key": "install-wasi-adapter",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "install-lsp": {
               "ty": "denoFile@v1",
               "key": "install-lsp",
-              "envKey": "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy"
+              "envKey": "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq"
             },
             "install-website": {
               "ty": "denoFile@v1",
               "key": "install-website",
-              "envKey": "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy"
+              "envKey": "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq"
             },
             "install-ts": {
               "ty": "denoFile@v1",
               "key": "install-ts",
-              "envKey": "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy"
+              "envKey": "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq"
             },
             "install-py": {
               "ty": "denoFile@v1",
               "key": "install-py",
-              "envKey": "bciqfgfpcam23r6t6tpit5hjclrtwwptfo7yhwojwngqdm5xuhhcwgfa"
+              "envKey": "bciqmpo7soabnkxibgqgurlc5lfy4a7jeglk6v45x4e4k7wnmwmztaqq"
             },
             "install-sys": {
               "ty": "denoFile@v1",
               "key": "install-sys",
               "desc": "Print a command you can use to install system items",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "fetch-deno": {
               "ty": "denoFile@v1",
               "key": "fetch-deno",
               "desc": "Cache remote deno modules.",
-              "envKey": "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy"
+              "envKey": "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq"
             },
             "dev-website": {
               "ty": "denoFile@v1",
               "key": "dev-website",
               "workingDir": "./website",
               "desc": "Launch the website",
-              "envKey": "bciqo5weutvl3sad2b52cigsr7pkzjaj33odvx5jhxmkukmffwwibjga"
+              "envKey": "bciqadrkruydvgov2zwklcwohmuno4nalyc3pg3yomdumdxfstvo4pby"
+            },
+            "dev-gate5": {
+              "ty": "denoFile@v1",
+              "key": "dev-gate5",
+              "desc": "Launch the typegate from the latests published image.",
+              "envKey": "bciqikizsspknj3opc7ld3zvrfnjlv37e67vhqcz6igd4dtvffgcyokq"
+            },
+            "dev-gate4": {
+              "ty": "denoFile@v1",
+              "key": "dev-gate4",
+              "desc": "Launch the typegate from the locally built typegate image.",
+              "envKey": "bciqikizsspknj3opc7ld3zvrfnjlv37e67vhqcz6igd4dtvffgcyokq"
+            },
+            "dev-gate3": {
+              "ty": "denoFile@v1",
+              "key": "dev-gate3",
+              "desc": "Launch the typegate from a locally found meta bin.",
+              "envKey": "bciqikizsspknj3opc7ld3zvrfnjlv37e67vhqcz6igd4dtvffgcyokq"
             },
             "dev-gate2": {
               "ty": "denoFile@v1",
               "key": "dev-gate2",
               "desc": "Launch the typegate in sync mode.",
-              "envKey": "bciqjfazgnyxehqdfwztfmuymn25mgqm3uq5yelkqbpd5bcdkyyr5bdq"
+              "envKey": "bciqh7p45mporp4lmdynwq3xdlhbkauaww7ggluc2bzqgpkxyw7j76fq"
             },
             "dev-gate1": {
               "ty": "denoFile@v1",
               "key": "dev-gate1",
               "desc": "Launch the typegate in single-instance mode.",
-              "envKey": "bciqmxq7fex7x2jkdb6dxzvyqcdjopabf6bhclywyvzclkhflp2vi6ci"
+              "envKey": "bciqikizsspknj3opc7ld3zvrfnjlv37e67vhqcz6igd4dtvffgcyokq"
             },
             "dev-eg-tgraphs": {
               "ty": "denoFile@v1",
               "key": "dev-eg-tgraphs",
               "desc": "meta dev example/typegraphs",
-              "envKey": "bciqhciuagnfwex2iffsvdcb7qvazygu3yvwuvt5f6u4xyye7cfxf62a"
+              "envKey": "bciqgpx2na2og2c3ty363m2kq3gficj4l4wxlpnrwl5gqiuzooondwja"
             },
             "dev-compose": {
               "ty": "denoFile@v1",
               "key": "dev-compose",
               "desc": "Wrapper around docker compose to manage runtime dependencies",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "dev": {
               "ty": "denoFile@v1",
               "key": "dev",
               "desc": "Execute dev/*.ts scripts.",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "gen-pyrt-bind": {
               "ty": "denoFile@v1",
               "key": "gen-pyrt-bind",
-              "envKey": "bciqjpe3qes7txbsoqf3vxksr3f7wglk2gb2wzi2qu2bmopfrtee56ly"
+              "envKey": "bciqbc7tuunt52ewlomqkynauomfweotxpf6hzut7yz532bwk2gckn5a"
             },
             "build-pyrt": {
               "ty": "denoFile@v1",
@@ -1397,17 +1415,17 @@
               "dependsOn": [
                 "gen-pyrt-bind"
               ],
-              "envKey": "bciqjpe3qes7txbsoqf3vxksr3f7wglk2gb2wzi2qu2bmopfrtee56ly"
+              "envKey": "bciqbc7tuunt52ewlomqkynauomfweotxpf6hzut7yz532bwk2gckn5a"
             },
             "build-tgraph-ts-jsr": {
               "ty": "denoFile@v1",
               "key": "build-tgraph-ts-jsr",
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "build-tgraph-core": {
               "ty": "denoFile@v1",
               "key": "build-tgraph-core",
-              "envKey": "bciqfmm5ettbkgirjn4nkdpqsvno4pshaxnruan64q7lzhx2mey2a6ua"
+              "envKey": "bciqlo5nwzz6bg3k475s2w42hxaqdkixdva6tnew5gghedac5d3ng43y"
             },
             "build-tgraph-py": {
               "ty": "denoFile@v1",
@@ -1415,7 +1433,7 @@
               "dependsOn": [
                 "build-tgraph-core"
               ],
-              "envKey": "bciqlnczvw5r6erqm4vm5qffeg2hgtapvbpjjsapmbial3tlznbzjwoi"
+              "envKey": "bciqi3ve7wig2zhcduvq2kt63yovunribk6kzbha3nucg5fkcuabt7xa"
             },
             "build-tgraph-ts": {
               "ty": "denoFile@v1",
@@ -1423,7 +1441,7 @@
               "dependsOn": [
                 "build-tgraph-core"
               ],
-              "envKey": "bciqmbwvn7ih4u22vuxfgcw3r2mjgqox2wa3ygze7yrgd24gkjp5sifq"
+              "envKey": "bciqasechgtqcnyliotc6k53o62vzvfm5jut74mgewfwoz7j7szvibci"
             },
             "build-tgraph-ts-node": {
               "ty": "denoFile@v1",
@@ -1431,7 +1449,7 @@
               "dependsOn": [
                 "build-tgraph-ts"
               ],
-              "envKey": "bciqmbwvn7ih4u22vuxfgcw3r2mjgqox2wa3ygze7yrgd24gkjp5sifq"
+              "envKey": "bciqasechgtqcnyliotc6k53o62vzvfm5jut74mgewfwoz7j7szvibci"
             },
             "build-tgraph": {
               "ty": "denoFile@v1",
@@ -1440,12 +1458,12 @@
                 "build-tgraph-py",
                 "build-tgraph-ts-node"
               ],
-              "envKey": "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi"
+              "envKey": "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi"
             },
             "build-sys-tgraphs": {
               "ty": "denoFile@v1",
               "key": "build-sys-tgraphs",
-              "envKey": "bciqk6vtevi3uhed6toozarvuqez7nhcafw72ex5fetqxof3b3aqm3la"
+              "envKey": "bciqdvyz2p7j7h7mk6edcuetyuu3qaexepnlzvh57auyrscxa7nx6n2q"
             }
           },
           "tasksNamed": [
@@ -1465,6 +1483,9 @@
             "install-sys",
             "fetch-deno",
             "dev-website",
+            "dev-gate5",
+            "dev-gate4",
+            "dev-gate3",
             "dev-gate2",
             "dev-gate1",
             "dev-eg-tgraphs",
@@ -1486,7 +1507,7 @@
         "id": "envs",
         "config": {
           "envs": {
-            "bciqh67lbrzxdurxdyghhngxyhq5yllkjb4ubg6ewofj4azspil2sghq": {
+            "bciqc6sjkyyjd32glkf553dkax7lw66qkdlk4cvpwlnkqy62h3yz3bcy": {
               "desc": "the default default environment.",
               "provides": [
                 {
@@ -1496,8 +1517,26 @@
                 },
                 {
                   "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
+                  "key": "TYPEGRAPH_VERSION",
+                  "val": "0.0.3"
+                },
+                {
+                  "ty": "posix.envVar",
+                  "key": "CLICOLOR_FORCE",
                   "val": "1"
+                },
+                {
+                  "ty": "ghjk.ports.InstallSetRef",
+                  "setId": "ghjkEnvProvInstSet___main"
+                }
+              ]
+            },
+            "bciqafqvagd25nwvgyjqhk2rad3icmbdk5ezxckgfmqklfkb6lc7jvpi": {
+              "provides": [
+                {
+                  "ty": "posix.envVar",
+                  "key": "RUST_LOG",
+                  "val": "info,swc_ecma_codegen=off,tracing::span=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1515,45 +1554,12 @@
                 }
               ]
             },
-            "bciqdohetprvjln4qpn2tot4epa7ikgm5nrevk2ouajpxvb6aistoroi": {
+            "bciqgbrnhfvvtmoua3evkupx3f7tt6ma45tpnjsoh5lw5y2igquul76y": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "TYPEGRAPH_VERSION",
-                  "val": "0.0.3"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "CLICOLOR_FORCE",
-                  "val": "1"
-                },
-                {
-                  "ty": "ghjk.ports.InstallSetRef",
-                  "setId": "ghjkEnvProvInstSet___main"
-                }
-              ]
-            },
-            "bciqkoolzb5k3ydzj3hahandxkfaxljpgidgdi6hpvrwxwal3ahmpi6y": {
-              "provides": [
-                {
-                  "ty": "posix.envVar",
-                  "key": "RUST_LOG",
-                  "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1571,17 +1577,12 @@
                 }
               ]
             },
-            "bciqjpe3qes7txbsoqf3vxksr3f7wglk2gb2wzi2qu2bmopfrtee56ly": {
+            "bciqbc7tuunt52ewlomqkynauomfweotxpf6hzut7yz532bwk2gckn5a": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1599,17 +1600,12 @@
                 }
               ]
             },
-            "bciqfgfpcam23r6t6tpit5hjclrtwwptfo7yhwojwngqdm5xuhhcwgfa": {
+            "bciqmpo7soabnkxibgqgurlc5lfy4a7jeglk6v45x4e4k7wnmwmztaqq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1627,17 +1623,12 @@
                 }
               ]
             },
-            "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy": {
+            "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1655,17 +1646,12 @@
                 }
               ]
             },
-            "bciqo5weutvl3sad2b52cigsr7pkzjaj33odvx5jhxmkukmffwwibjga": {
+            "bciqadrkruydvgov2zwklcwohmuno4nalyc3pg3yomdumdxfstvo4pby": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1688,17 +1674,12 @@
                 }
               ]
             },
-            "bciqneegebfsc27gmtujwohhnwgziarymoanrpurvoxywgrg7orewtgy": {
+            "bciqahf2tfeocjdxm6vt4py7nen4konon5ufmjszqkuo4drhtj445zyi": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1716,17 +1697,12 @@
                 }
               ]
             },
-            "bciqi3e7xmx27tdbvjwwwmh3tetevp3apldch7ifbpauxsovl4cohudq": {
+            "bciqov4rontailrkkhq4mmg6unksfithoszn3abi3pyfqnvlh6ynkvka": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1744,17 +1720,12 @@
                 }
               ]
             },
-            "bciqmxq7fex7x2jkdb6dxzvyqcdjopabf6bhclywyvzclkhflp2vi6ci": {
+            "bciqikizsspknj3opc7ld3zvrfnjlv37e67vhqcz6igd4dtvffgcyokq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1807,17 +1778,12 @@
                 }
               ]
             },
-            "bciqjfazgnyxehqdfwztfmuymn25mgqm3uq5yelkqbpd5bcdkyyr5bdq": {
+            "bciqh7p45mporp4lmdynwq3xdlhbkauaww7ggluc2bzqgpkxyw7j76fq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1910,17 +1876,12 @@
                 }
               ]
             },
-            "bciqhciuagnfwex2iffsvdcb7qvazygu3yvwuvt5f6u4xyye7cfxf62a": {
+            "bciqgpx2na2og2c3ty363m2kq3gficj4l4wxlpnrwl5gqiuzooondwja": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1938,17 +1899,12 @@
                 }
               ]
             },
-            "bciqfmm5ettbkgirjn4nkdpqsvno4pshaxnruan64q7lzhx2mey2a6ua": {
+            "bciqlo5nwzz6bg3k475s2w42hxaqdkixdva6tnew5gghedac5d3ng43y": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1971,17 +1927,12 @@
                 }
               ]
             },
-            "bciqlnczvw5r6erqm4vm5qffeg2hgtapvbpjjsapmbial3tlznbzjwoi": {
+            "bciqi3ve7wig2zhcduvq2kt63yovunribk6kzbha3nucg5fkcuabt7xa": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -2004,17 +1955,12 @@
                 }
               ]
             },
-            "bciqmbwvn7ih4u22vuxfgcw3r2mjgqox2wa3ygze7yrgd24gkjp5sifq": {
+            "bciqasechgtqcnyliotc6k53o62vzvfm5jut74mgewfwoz7j7szvibci": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -2037,17 +1983,12 @@
                 }
               ]
             },
-            "bciqk6vtevi3uhed6toozarvuqez7nhcafw72ex5fetqxof3b3aqm3la": {
+            "bciqdvyz2p7j7h7mk6edcuetyuu3qaexepnlzvh57auyrscxa7nx6n2q": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -2065,17 +2006,12 @@
                 }
               ]
             },
-            "bciqcwkq6wg63c6swnk5bcpk6svhd35mptdi5dzdv6vxb75zc7ooq24i": {
+            "bciqdyc67uwyl5pkoaaohvgmnpdtuamame6zvktiegfai562fuw5oiiq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -2093,17 +2029,12 @@
                 }
               ]
             },
-            "bciqm6h3xtp5dbm5fjfjxzt2tz4nah3kgfawp6nam3kbsjmdm47nansa": {
+            "bciqf76zyyuyjv6qftg3snjga2c5me32myn2nxlclr4kryuy2nobtbii": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -2121,17 +2052,12 @@
                 }
               ]
             },
-            "bciqlgq5a24bktwn7jeyggh7mwqabdjyk4mbu43bs2vt2nhnusxxpygq": {
+            "bciqkx557bvfx3hn4pl47jx75x37twor5h5jarz7kbk2tvzqv4xpw3vq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
                   "val": "info,swc_ecma_codegen=off,tracing::span=off"
-                },
-                {
-                  "ty": "posix.envVar",
-                  "key": "WASMTIME_BACKTRACE_DETAILS",
-                  "val": "1"
                 },
                 {
                   "ty": "posix.envVar",
@@ -2152,14 +2078,14 @@
           },
           "defaultEnv": "dev",
           "envsNamed": {
-            "main": "bciqh67lbrzxdurxdyghhngxyhq5yllkjb4ubg6ewofj4azspil2sghq",
-            "_wasm": "bciqjpe3qes7txbsoqf3vxksr3f7wglk2gb2wzi2qu2bmopfrtee56ly",
-            "_python": "bciqfgfpcam23r6t6tpit5hjclrtwwptfo7yhwojwngqdm5xuhhcwgfa",
-            "_ecma": "bciqfc7xpvg2we63kzdrshwyjudryc64lekcg2msgqnff7mnvox7n4fy",
-            "_rust": "bciqneegebfsc27gmtujwohhnwgziarymoanrpurvoxywgrg7orewtgy",
-            "ci": "bciqcwkq6wg63c6swnk5bcpk6svhd35mptdi5dzdv6vxb75zc7ooq24i",
-            "dev": "bciqm6h3xtp5dbm5fjfjxzt2tz4nah3kgfawp6nam3kbsjmdm47nansa",
-            "oci": "bciqlgq5a24bktwn7jeyggh7mwqabdjyk4mbu43bs2vt2nhnusxxpygq"
+            "main": "bciqc6sjkyyjd32glkf553dkax7lw66qkdlk4cvpwlnkqy62h3yz3bcy",
+            "_wasm": "bciqbc7tuunt52ewlomqkynauomfweotxpf6hzut7yz532bwk2gckn5a",
+            "_python": "bciqmpo7soabnkxibgqgurlc5lfy4a7jeglk6v45x4e4k7wnmwmztaqq",
+            "_ecma": "bciqg5tyxjk3n5hnomlukrr4jty54ne4kfzthqbqmef6tsze4thjl6xq",
+            "_rust": "bciqahf2tfeocjdxm6vt4py7nen4konon5ufmjszqkuo4drhtj445zyi",
+            "ci": "bciqdyc67uwyl5pkoaaohvgmnpdtuamame6zvktiegfai562fuw5oiiq",
+            "dev": "bciqf76zyyuyjv6qftg3snjga2c5me32myn2nxlclr4kryuy2nobtbii",
+            "oci": "bciqkx557bvfx3hn4pl47jx75x37twor5h5jarz7kbk2tvzqv4xpw3vq"
           }
         }
       }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "meta-cli"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "actix",
  "assert_cmd",
@@ -6526,7 +6526,7 @@ dependencies = [
 
 [[package]]
 name = "metagen"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "color-eyre",
  "common",
@@ -6853,7 +6853,7 @@ dependencies = [
 
 [[package]]
 name = "mt_deno"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "deno",
@@ -12121,7 +12121,7 @@ dependencies = [
 
 [[package]]
 name = "typegate"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "colored",
  "env_logger 0.11.0",
@@ -12134,7 +12134,7 @@ dependencies = [
 
 [[package]]
 name = "typegate_engine"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12174,7 +12174,7 @@ dependencies = [
 
 [[package]]
 name = "typegraph_core"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "color-eyre",
@@ -13909,7 +13909,7 @@ checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xtask"
-version = "0.4.8-0"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "libs/pyrt_wit_wire",
 ]
 [workspace.package] 
-version = "0.4.8-0"
+version = "0.4.8"
 edition = "2021"
 
 [workspace.dependencies]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -73,7 +73,7 @@ RUN . "$GHJK_ACTIVATE" \
 COPY . .
 
 RUN . "$GHJK_ACTIVATE" \
-    && cargo build --profile $CARGO_PROFILE --package typegate \
+    && cargo build --profile $CARGO_PROFILE --package typegate --locked \
     && ( \
         [ $CARGO_PROFILE = 'release' ]  \
             && cp target/release/typegate typegate-bin \
@@ -110,6 +110,11 @@ RUN . "$GHJK_ACTIVATE" \
 FROM gcr.io/distroless/cc-debian11:${DISTROLESS_TAG} as prd
 
 SHELL ["/busybox/sh", "-c"]
+
+# hack for https://github.com/GoogleContainerTools/distroless/issues/1643
+USER root
+RUN chown 65532:65532 /home/nonroot
+USER nonroot
 
 ARG TARGETARCH
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -111,11 +111,6 @@ FROM gcr.io/distroless/cc-debian11:${DISTROLESS_TAG} as prd
 
 SHELL ["/busybox/sh", "-c"]
 
-# hack for https://github.com/GoogleContainerTools/distroless/issues/1643
-USER root
-RUN chown 65532:65532 /home/nonroot
-USER nonroot
-
 ARG TARGETARCH
 
 ENV NO_COLOR true

--- a/dev/Dockerfile.dockerignore
+++ b/dev/Dockerfile.dockerignore
@@ -15,3 +15,4 @@ libs/metagen/tests/
 !typegate/import_map.json
 !ghjk.ts
 !Cargo.toml
+!Cargo.lock

--- a/dev/consts.ts
+++ b/dev/consts.ts
@@ -1,7 +1,7 @@
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
-export const METATYPE_VERSION = "0.4.8-0";
+export const METATYPE_VERSION = "0.4.8";
 export const PUBLISHED_VERSION = "0.4.7";
 export const GHJK_VERSION = "b702292";
 export const GHJK_ACTION_VERSION = "318209a9d215f70716a4ac89dbeb9653a2deb8bc";

--- a/dev/tasks-dev.ts
+++ b/dev/tasks-dev.ts
@@ -109,6 +109,47 @@ const tasks: Record<string, DenoTaskDefArgs> = {
     fn: ($) => $`cargo run -p typegate`,
   },
 
+  "dev-gate3": {
+    desc: "Launch the typegate from a locally found meta bin.",
+    inherit: "dev-gate1",
+    fn: ($) => $`meta typegate`,
+  },
+
+  "dev-gate4": {
+    desc: "Launch the typegate from the locally built typegate image.",
+    inherit: "dev-gate1",
+    fn: ($) =>
+      $`docker run --rm -it
+        --network=host
+        -e TG_PORT=7891
+        -e PACKAGED=false
+        -e LOG_LEVEL=DEBUG
+        -e DEBUG=true
+        -e REDIS_URL=redis://:password@localhost:6379/0
+        -e TG_SECRET=a4lNi0PbEItlFZbus1oeH/+wyIxi9uH6TpL8AIqIaMBNvp7SESmuUBbfUwC0prxhGhZqHw8vMDYZAGMhSZ4fLw==
+        -e TG_ADMIN_PASSWORD=password
+        typegate:latest
+    `,
+  },
+
+  "dev-gate5": {
+    desc: "Launch the typegate from the latests published image.",
+    inherit: "dev-gate1",
+    fn: ($) =>
+      $`docker run --rm -it
+        --network=host
+        -p 7891:7891
+        -e TG_PORT=7891
+        -e PACKAGED=false
+        -e LOG_LEVEL=DEBUG
+        -e DEBUG=true
+        -e REDIS_URL=redis://:password@localhost:6379/0
+        -e TG_SECRET=a4lNi0PbEItlFZbus1oeH/+wyIxi9uH6TpL8AIqIaMBNvp7SESmuUBbfUwC0prxhGhZqHw8vMDYZAGMhSZ4fLw==
+        -e TG_ADMIN_PASSWORD=password
+        ghcr.io/metatypedev/typegate:latest
+    `,
+  },
+
   "dev-website": {
     desc: "Launch the website",
     inherit: ["_ecma", "_python"],

--- a/dev/test.ts
+++ b/dev/test.ts
@@ -207,10 +207,14 @@ export async function testE2e(args: {
 
   const queue = [...filteredTestFiles];
 
+  const buildProfile = profile == "debug" ? "dev" : profile;
+
   $.logStep(`${prefix} Building xtask and meta-cli...`);
-  await $`cargo build -p meta-cli -F typegate --${profile}
+  await $`cargo build -p meta-cli -F typegate --profile ${buildProfile}
           && mv target/${profile}/meta target/${profile}/meta-full
-          && cargo build -p xtask -p meta-cli --${profile}`.cwd(wd);
+          && cargo build -p xtask -p meta-cli --profile ${buildProfile}`.cwd(
+    wd,
+  );
 
   $.logStep(`Discovered ${queue.length} test files to run`);
 

--- a/dev/test.ts
+++ b/dev/test.ts
@@ -207,12 +207,10 @@ export async function testE2e(args: {
 
   const queue = [...filteredTestFiles];
 
-  const buildProfile = profile == "debug" ? "dev" : profile;
-
   $.logStep(`${prefix} Building xtask and meta-cli...`);
-  await $`cargo build -p meta-cli -F typegate --${buildProfile}
+  await $`cargo build -p meta-cli -F typegate --${profile}
           && mv target/${profile}/meta target/${profile}/meta-full
-          && cargo build -p xtask -p meta-cli --${buildProfile}`.cwd(wd);
+          && cargo build -p xtask -p meta-cli --${profile}`.cwd(wd);
 
   $.logStep(`Discovered ${queue.length} test files to run`);
 

--- a/examples/templates/deno/compose.yml
+++ b/examples/templates/deno/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.4.8-0
+    image: ghcr.io/metatypedev/typegate:v0.4.8
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/compose.yml
+++ b/examples/templates/node/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.4.8-0
+    image: ghcr.io/metatypedev/typegate:v0.4.8
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/package.json
+++ b/examples/templates/node/package.json
@@ -6,7 +6,7 @@
     "dev": "MCLI_LOADER_CMD='npm x tsx' meta dev"
   },
   "dependencies": {
-    "@typegraph/sdk": "^0.4.8-0"
+    "@typegraph/sdk": "^0.4.8"
   },
   "devDependencies": {
     "tsx": "^3.13.0",

--- a/examples/templates/python/compose.yml
+++ b/examples/templates/python/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.4.8-0
+    image: ghcr.io/metatypedev/typegate:v0.4.8
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/python/pyproject.toml
+++ b/examples/templates/python/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "example"
-version = "0.4.8-0"
+version = "0.4.8"
 description = ""
 authors = []
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-typegraph = "0.4.8-0"
+typegraph = "0.4.8"
 
 [build-system]
 requires = ["poetry-core"]

--- a/ghjk.ts
+++ b/ghjk.ts
@@ -28,7 +28,6 @@ env("main")
   .install(installs.deno)
   .vars({
     RUST_LOG: "info,swc_ecma_codegen=off,tracing::span=off",
-    WASMTIME_BACKTRACE_DETAILS: "1",
     TYPEGRAPH_VERSION: "0.0.3",
     CLICOLOR_FORCE: "1",
   })

--- a/libs/common/Cargo.toml
+++ b/libs/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.4.8-0"
+version = "0.4.8"
 edition = "2021"
 
 [dependencies]

--- a/libs/metagen/tests/mat_rust/Cargo.toml
+++ b/libs/metagen/tests/mat_rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mat_rust"
 edition = "2021"
-version = "0.4.8-0"
+version = "0.4.8"
 
 [workspace]
 members = ["gen"]

--- a/libs/pyrt_wit_wire/pyproject.toml
+++ b/libs/pyrt_wit_wire/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrt_wit_wire"
-version = "0.4.8-0"
+version = "0.4.8"
 description = "Wasm component implementing the PythonRuntime host using wit_wire protocol."
 license = "Elastic-2.0"
 readme = "README.md"

--- a/libs/xtask/Cargo.toml
+++ b/libs/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.4.8-0"
+version = "0.4.8"
 edition = "2021"
 
 [dependencies]

--- a/meta-cli/Cargo.toml
+++ b/meta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meta-cli"
-version = "0.4.8-0"
+version = "0.4.8"
 edition = "2021"
 
 description = "Declarative API development platform. Build backend components with WASM, Typescript and Python, no matter where and how your (legacy) systems are."

--- a/meta-lsp/package.json
+++ b/meta-lsp/package.json
@@ -4,7 +4,7 @@
   "description": "VSCode extension for Metatype support",
   "icon": "logo.png",
   "author": "Metatype Team",
-  "version": "0.4.8-0",
+  "version": "0.4.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/meta-lsp/ts-language-server/package.json
+++ b/meta-lsp/ts-language-server/package.json
@@ -2,7 +2,7 @@
   "name": "typegraph-ts-server",
   "description": "TypeScript language server for TypeGraph",
   "author": "Metatype Team",
-  "version": "0.4.8-0",
+  "version": "0.4.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/meta-lsp/vscode-metatype-support/package.json
+++ b/meta-lsp/vscode-metatype-support/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-metatype-support",
   "description": "VSCode extension for Metatype support",
   "author": "Metatype Team",
-  "version": "0.4.8-0",
+  "version": "0.4.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metatype"
-version = "0.4.8-0"
+version = "0.4.8"
 description = ""
 authors = []
 

--- a/typegate/engine/build.rs
+++ b/typegate/engine/build.rs
@@ -48,6 +48,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let engine = wasmtime::Engine::new(
         wasmtime::Config::new()
+            .wasm_backtrace(true)
+            // embedded wasm images have backtrace enabled
+            .wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable)
             .cache_config_load_default()
             .map_err(|err| format!("error reading system's wasmtime cache config: {err}"))?
             .target(&target)

--- a/typegate/engine/src/lib.rs
+++ b/typegate/engine/src/lib.rs
@@ -77,6 +77,9 @@ impl OpDepInjector {
         let engine = wasmtime::Engine::new(
             wasmtime::Config::new()
                 .async_support(true)
+                .wasm_backtrace(true)
+                // embedded wasm images have backtrace enabled
+                .wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable)
                 .cache_config_load_default()
                 .context("error reading system's wasmtime cache config")
                 .unwrap(),

--- a/typegate/src/runtimes/wit_wire/mod.ts
+++ b/typegate/src/runtimes/wit_wire/mod.ts
@@ -9,7 +9,7 @@ import { getLogger } from "../../log.ts";
 
 const logger = getLogger(import.meta);
 
-const METATYPE_VERSION = "0.4.8-0";
+const METATYPE_VERSION = "0.4.8";
 
 export class WitWireMessenger {
   static async init(

--- a/typegate/tests/metagen/__snapshots__/metagen_test.ts.snap
+++ b/typegate/tests/metagen/__snapshots__/metagen_test.ts.snap
@@ -362,7 +362,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.4.8-0";
+        static MT_VERSION: &str = "0.4.8";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }
@@ -1106,7 +1106,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.4.8-0";
+        static MT_VERSION: &str = "0.4.8";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }

--- a/typegate/tests/runtimes/wasm_reflected/rust/Cargo.toml
+++ b/typegate/tests/runtimes/wasm_reflected/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust"
-version = "0.4.8-0"
+version = "0.4.8"
 edition = "2021"
 
 [lib]

--- a/typegraph/core/Cargo.toml
+++ b/typegraph/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typegraph_core"
-version = "0.4.8-0"
+version = "0.4.8"
 edition = "2021"
 
 [lib]

--- a/typegraph/core/src/global_store.rs
+++ b/typegraph/core/src/global_store.rs
@@ -102,7 +102,7 @@ const PREDEFINED_DENO_FUNCTIONS: &[&str] = &["identity", "true"];
 
 thread_local! {
     pub static STORE: RefCell<Store> = RefCell::new(Store::new());
-    pub static SDK_VERSION: String = "0.4.8-0".to_owned();
+    pub static SDK_VERSION: String = "0.4.8".to_owned();
 }
 
 fn with_store<T, F: FnOnce(&Store) -> T>(f: F) -> T {

--- a/typegraph/deno/sdk/jsr.json
+++ b/typegraph/deno/sdk/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@typegraph/sdk",
-  "version": "0.4.8-0",
+  "version": "0.4.8",
   "publish": {
     "exclude": [
       "!src/gen",

--- a/typegraph/python/pyproject.toml
+++ b/typegraph/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typegraph"
-version = "0.4.8-0"
+version = "0.4.8"
 description = "Declarative API development platform. Build backend components with WASM, Typescript and Python, no matter where and how your (legacy) systems are."
 authors = ["Metatype Contributors <support@metatype.dev>"]
 license = "MPL-2.0"

--- a/typegraph/python/typegraph/__init__.py
+++ b/typegraph/python/typegraph/__init__.py
@@ -5,4 +5,4 @@ from typegraph.graph.typegraph import typegraph, Graph  # noqa
 from typegraph.policy import Policy  # noqa
 from typegraph import effects as fx  # noqa
 
-version = "0.4.8-0"
+version = "0.4.8"


### PR DESCRIPTION
- `$WASM_BACKTRACE_DETAILS` was enabled in `main` ghjk env which affected embedded wasm module compilation to have backtrace enabled. This broke typegate runs without the flag enabled due to mismatch.
- Fixes Cargo.lock not being used in Dockerfile.
- Prepare 0.4.8 release