### PR TITLE
feat: extend typegraph_core

### DIFF
--- a/src/typegraph/core/Cargo.toml
+++ b/src/typegraph/core/Cargo.toml
@@ -3,8 +3,9 @@ name = "typegraph_core"
 version = "0.4.11-rc.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
+# passed from the cmdline when compiling to wasm
+# [lib]
+# crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 common.workspace = true
@@ -32,6 +33,9 @@ sha2.workspace = true
 seahash.workspace = true
 
 glob.workspace = true
+
+[features]
+wasm = []
 
 [dev-dependencies]
 insta = { workspace = true, features = ["glob"] }

--- a/src/typegraph/core/src/lib.rs
+++ b/src/typegraph/core/src/lib.rs
@@ -551,7 +551,7 @@ impl wit::core::Guest for Lib {
     }
 }
 
-// TODO: How about this one?
+#[cfg(feature = "wasm")]
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => {

--- a/src/typegraph/core/src/lib.rs
+++ b/src/typegraph/core/src/lib.rs
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 mod conversion;
-mod errors;
 mod global_store;
 mod logger;
 mod params;
 mod runtimes;
-mod t;
 mod typedef;
 mod typegraph;
-mod types;
 mod utils;
 mod validation;
 
@@ -38,6 +35,11 @@ use wit::core::{
 };
 use wit::runtimes::{Guest, MaterializerDenoFunc};
 
+pub mod errors;
+pub mod t;
+pub mod types;
+
+#[cfg(feature = "wasm")]
 pub mod wit {
     wit_bindgen::generate!({
         world: "typegraph"
@@ -46,6 +48,19 @@ pub mod wit {
     pub use exports::metatype::typegraph::{aws, core, runtimes, utils};
     export!(Lib);
 }
+
+#[cfg(not(feature = "wasm"))]
+mod wit {
+    wit_bindgen::generate!({
+        world: "typegraph"
+    });
+    pub use exports::metatype::typegraph::{aws, core, runtimes, utils};
+}
+
+pub use crate::wit::aws::Guest as LibAws;
+pub use crate::wit::core::Guest as LibCore;
+pub use crate::wit::runtimes::Guest as LibRuntime;
+pub use crate::wit::utils::Guest as LibUtil;
 
 pub struct Lib {}
 

--- a/src/typegraph/core/src/lib.rs
+++ b/src/typegraph/core/src/lib.rs
@@ -551,6 +551,7 @@ impl wit::core::Guest for Lib {
     }
 }
 
+// TODO: How about this one?
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => {

--- a/src/typegraph/core/src/logger.rs
+++ b/src/typegraph/core/src/logger.rs
@@ -9,7 +9,7 @@ macro_rules! debug {
 
             let mut msg = "debug: ".to_string();
             write!(&mut msg, $($arg)*).unwrap();
-            $crate::wit::metatype::typegraph::host::print(&msg);
+            $crate::utils::io::print(&msg);
         }
     };
 }
@@ -22,7 +22,7 @@ macro_rules! info {
 
             let mut msg = "info: ".to_string();
             write!(&mut msg, $($arg)*).unwrap();
-            $crate::wit::metatype::typegraph::host::print(&msg);
+            $crate::utils::io::print(&msg);
         }
     };
 }
@@ -35,7 +35,7 @@ macro_rules! warning {
 
             let mut msg = "warn: ".to_string();
             write!(&mut msg, $($arg)*).unwrap();
-            $crate::wit::metatype::typegraph::host::print(&msg);
+            $crate::utils::io::print(&msg);
         }
     };
 }
@@ -48,7 +48,7 @@ macro_rules! error {
 
             let mut msg = "error: ".to_string();
             write!(&mut msg, $($arg)*).unwrap();
-            $crate::wit::metatype::typegraph::host::print(&msg);
+            $crate::utils::io::print(&msg);
         }
     };
 }

--- a/src/typegraph/core/src/t.rs
+++ b/src/typegraph/core/src/t.rs
@@ -32,7 +32,6 @@ impl TypeBuilder for TypeId {
     }
 }
 
-#[allow(unused)]
 pub trait ConcreteTypeBuilder: TypeBuilder {
     fn base_mut(&mut self) -> &mut TypeBase;
     fn xbase_mut(&mut self) -> &mut ExtendedTypeBase;
@@ -105,25 +104,21 @@ impl Default for TypeInteger {
 }
 
 impl IntegerBuilder {
-    #[allow(dead_code)]
     pub fn min(mut self, min: i32) -> Self {
         self.data.min = Some(min);
         self
     }
 
-    #[allow(dead_code)]
     pub fn max(mut self, max: i32) -> Self {
         self.data.max = Some(max);
         self
     }
 
-    #[allow(dead_code)]
     pub fn x_min(mut self, min: i32) -> Self {
         self.data.exclusive_minimum = Some(min);
         self
     }
 
-    #[allow(dead_code)]
     pub fn x_max(mut self, max: i32) -> Self {
         self.data.exclusive_maximum = Some(max);
         self
@@ -156,25 +151,21 @@ impl Default for TypeFloat {
 }
 
 impl FloatBuilder {
-    #[allow(dead_code)]
     pub fn min(mut self, min: f64) -> Self {
         self.data.min = Some(min);
         self
     }
 
-    #[allow(dead_code)]
     pub fn max(mut self, max: f64) -> Self {
         self.data.max = Some(max);
         self
     }
 
-    #[allow(dead_code)]
     pub fn x_min(mut self, min: f64) -> Self {
         self.data.exclusive_minimum = Some(min);
         self
     }
 
-    #[allow(dead_code)]
     pub fn x_max(mut self, max: f64) -> Self {
         self.data.exclusive_maximum = Some(max);
         self
@@ -210,7 +201,6 @@ pub fn string() -> StringBuilder {
 }
 
 impl StringBuilder {
-    #[allow(dead_code)]
     pub fn format(&mut self, format: impl Into<String>) -> &mut Self {
         self.data.format = Some(format.into());
         self
@@ -425,7 +415,6 @@ impl StructBuilder {
         Ok(self)
     }
 
-    #[allow(dead_code)]
     pub fn props(&mut self, props: impl IntoIterator<Item = (String, TypeId)>) {
         self.data
             .props
@@ -437,7 +426,6 @@ impl StructBuilder {
         self
     }
 
-    #[allow(dead_code)]
     pub fn max(&mut self, max: u32) -> &mut Self {
         self.data.max = Some(max);
         self
@@ -464,7 +452,6 @@ impl Default for TypeFunc {
     }
 }
 
-#[allow(dead_code)]
 pub fn func(inp: TypeId, out: TypeId, mat: u32) -> Result<TypeId> {
     FuncBuilder {
         data: TypeFunc {

--- a/src/typegraph/core/src/t.rs
+++ b/src/typegraph/core/src/t.rs
@@ -5,8 +5,8 @@ use crate::errors::Result;
 use crate::global_store::{NameRegistration, Store};
 use crate::types::{ExtendedTypeBase, TypeDefExt, TypeId};
 use crate::wit::core::{
-    Guest, TypeBase, TypeEither, TypeFloat, TypeFunc, TypeInteger, TypeList, TypeOptional,
-    TypeString, TypeStruct, TypeUnion,
+    FuncParams, Guest, TypeBase, TypeEither, TypeFloat, TypeFunc, TypeInteger, TypeList,
+    TypeOptional, TypeString, TypeStruct, TypeUnion,
 };
 
 pub trait TypeBuilder {
@@ -463,6 +463,12 @@ pub fn func(inp: TypeId, out: TypeId, mat: u32) -> Result<TypeId> {
         ..Default::default()
     }
     .build()
+}
+
+impl TypeBuilder for FuncParams {
+    fn build(&self) -> Result<TypeId> {
+        func(self.inp.into(), self.out.into(), self.mat)
+    }
 }
 
 pub struct RefBuilder {

--- a/src/typegraph/core/src/types/mod.rs
+++ b/src/typegraph/core/src/types/mod.rs
@@ -10,6 +10,39 @@ pub use type_def::*;
 pub use type_id::*;
 pub use type_ref::*;
 
+pub mod core {
+    pub use crate::wit::core::{
+        Artifact, ContextCheck, Cors, Error, FuncParams, MaterializerId, MigrationAction,
+        ParameterTransform, Policy, PolicyId, PolicyPerEffect, PolicySpec, PrismaMigrationConfig,
+        Rate, RuntimeId, SerializeParams, TypeId, TypegraphInitParams,
+    };
+}
+
+pub mod runtimes {
+    pub use crate::wit::runtimes::{
+        BaseMaterializer, Effect, GraphqlRuntimeData, HttpMethod, HttpRuntimeData, KvMaterializer,
+        KvRuntimeData, MaterializerDenoFunc, MaterializerDenoImport, MaterializerDenoPredefined,
+        MaterializerDenoStatic, MaterializerGraphqlQuery, MaterializerHttpRequest,
+        MaterializerPythonDef, MaterializerPythonImport, MaterializerPythonLambda,
+        MaterializerPythonModule, MaterializerRandom, MaterializerWasmReflectedFunc,
+        MaterializerWasmWireHandler, PrismaLinkData, PrismaMigrationOperation, PrismaRuntimeData,
+        RandomRuntimeData, SubstantialOperationData, SubstantialOperationType,
+        SubstantialRuntimeData, TemporalOperationData, TemporalOperationType, TemporalRuntimeData,
+        TypegateOperation, TypegraphOperation, WasmRuntimeData, Workflow, WorkflowKind,
+    };
+}
+
+pub mod aws {
+    pub use crate::wit::aws::{S3PresignGetParams, S3PresignPutParams, S3RuntimeData};
+}
+
+pub mod utils {
+    pub use crate::wit::utils::{
+        Auth, AuthProtocol, MdkConfig, MdkOutput, QueryDeployParams, Reduce, ReducePath,
+        ReduceValue,
+    };
+}
+
 #[derive(Clone, Debug)]
 pub enum Type {
     Ref(TypeRef),

--- a/src/typegraph/core/src/utils/fs.rs
+++ b/src/typegraph/core/src/utils/fs.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use super::pathlib::PathLib;
-use crate::wit::metatype::typegraph::host::{
-    expand_path as expand_path_host, path_exists as path_exists_host, read_file as read_file_host,
-    write_file as write_file_host,
-};
 use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeSet,
     path::{Path, PathBuf},
+};
+
+use super::io::{
+    expand_path as expand_path_host, path_exists as path_exists_host, read_file as read_file_host,
+    write_file as write_file_host,
 };
 
 pub struct FsContext {

--- a/src/typegraph/core/src/utils/io.rs
+++ b/src/typegraph/core/src/utils/io.rs
@@ -1,3 +1,6 @@
+// Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
+// SPDX-License-Identifier: MPL-2.0
+
 #[cfg(feature = "wasm")]
 pub use crate::wit::metatype::typegraph::host::*;
 

--- a/src/typegraph/core/src/utils/io.rs
+++ b/src/typegraph/core/src/utils/io.rs
@@ -60,6 +60,7 @@ mod native {
     pub fn path_exists(path: &str) -> Result<bool, String> {
         match fs::metadata(path) {
             Ok(_) => Ok(true),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
             Err(err) => Err(err.to_string()),
         }
     }

--- a/src/typegraph/core/src/utils/io.rs
+++ b/src/typegraph/core/src/utils/io.rs
@@ -1,0 +1,78 @@
+#[cfg(feature = "wasm")]
+pub use crate::wit::metatype::typegraph::host::*;
+
+#[cfg(not(feature = "wasm"))]
+pub use native::*;
+
+#[cfg(not(feature = "wasm"))]
+mod native {
+    use regex::Regex;
+    use std::{env, fs, io};
+
+    fn match_path(path: &str, patterns: &[Regex]) -> bool {
+        patterns.iter().any(|pat| pat.is_match(path))
+    }
+
+    fn find_path_matches(
+        path: &str,
+        exclude: &[Regex],
+        results: &mut Vec<String>,
+    ) -> Result<(), io::Error> {
+        for entry in fs::read_dir(path)? {
+            let path = entry?.path();
+            let path_str = path.to_string_lossy();
+
+            if path.is_file() && match_path(&path_str, exclude) {
+                results.push(path_str.to_string());
+            } else if path.is_dir() {
+                find_path_matches(&path_str, exclude, results)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn print(s: &str) {
+        println!("{s}");
+    }
+
+    pub fn eprint(s: &str) {
+        eprintln!("{s}");
+    }
+
+    pub fn expand_path(path: &str, exclude: &[String]) -> Result<Vec<String>, String> {
+        let mut results = Vec::new();
+
+        let exclude = exclude
+            .iter()
+            .flat_map(|pat| Regex::new(pat))
+            .collect::<Vec<_>>();
+
+        match find_path_matches(path, &exclude, &mut results) {
+            Ok(_) => Ok(results),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    pub fn path_exists(path: &str) -> Result<bool, String> {
+        match fs::metadata(path) {
+            Ok(_) => Ok(true),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    pub fn read_file(path: &str) -> Result<Vec<u8>, String> {
+        fs::read(path).map_err(|err| err.to_string())
+    }
+
+    pub fn write_file(path: &str, data: &[u8]) -> Result<(), String> {
+        fs::write(path, data).map_err(|err| err.to_string())
+    }
+
+    pub fn get_cwd() -> Result<String, String> {
+        match env::current_dir() {
+            Ok(path) => Ok(path.to_string_lossy().to_string()),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+}

--- a/src/typegraph/core/src/utils/io.rs
+++ b/src/typegraph/core/src/utils/io.rs
@@ -13,7 +13,7 @@ mod native {
         patterns.iter().any(|pat| pat.is_match(path))
     }
 
-    fn find_path_matches(
+    fn expand_path_helper(
         path: &str,
         exclude: &[Regex],
         results: &mut Vec<String>,
@@ -22,10 +22,10 @@ mod native {
             let path = entry?.path();
             let path_str = path.to_string_lossy();
 
-            if path.is_file() && match_path(&path_str, exclude) {
+            if path.is_file() && !match_path(&path_str, exclude) {
                 results.push(path_str.to_string());
             } else if path.is_dir() {
-                find_path_matches(&path_str, exclude, results)?;
+                expand_path_helper(&path_str, exclude, results)?;
             }
         }
 
@@ -48,7 +48,7 @@ mod native {
             .flat_map(|pat| Regex::new(pat))
             .collect::<Vec<_>>();
 
-        match find_path_matches(path, &exclude, &mut results) {
+        match expand_path_helper(path, &exclude, &mut results) {
             Ok(_) => Ok(results),
             Err(err) => Err(err.to_string()),
         }

--- a/src/typegraph/core/src/utils/mod.rs
+++ b/src/typegraph/core/src/utils/mod.rs
@@ -29,6 +29,9 @@ mod pathlib;
 pub mod postprocess;
 pub mod reduce;
 
+#[allow(unused)]
+pub mod io;
+
 fn find_missing_props(
     supertype_id: TypeId,
     new_props: &Vec<(String, u32)>,

--- a/tools/tasks/build.ts
+++ b/tools/tasks/build.ts
@@ -31,7 +31,7 @@ export default {
     },
     async fn($) {
       const target = "wasm32-unknown-unknown";
-      await $`cargo build -p typegraph_core --target ${target} --release --target-dir target/wasm`;
+      await $`cargo rustc -p typegraph_core --target ${target} --crate-type=cdylib,rlib --features=wasm --release --target-dir target/wasm`;
       await $`cp target/wasm/${target}/release/typegraph_core.wasm $WASM_FILE.tmp`;
       if ($.env["WASM_OPT"]) {
         await $`wasm-opt -Oz $WASM_FILE.tmp -o $WASM_FILE.tmp`;


### PR DESCRIPTION
<!--
Pull requests are squashed and merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog.
-->

<!-- 1. Explain WHAT the change is about -->

I'm still not convinced about the actual use cases but this is a draft of how `typegraph_core` could be used as a normal rust library by reusing wit generated types which are just normal Rust types and without exposing ABI related functions.

It exposes some type related utils like the `t` module which was previously private and is quite similar to the one in python and typescript. Though there are currently no wrapper around runtimes.

<!-- 2. Explain WHY the change cannot be made simpler -->

<!-- 3. Explain HOW users should update their code -->

This is how it currently looks like: https://gist.github.com/luckasRanarison/26ceb1ed3152cadddf802a1f449c369d

#### Migration notes

...

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
