### PR TITLE
fix(subs): key collision on redis

### DIFF
--- a/src/typegate/src/runtimes/substantial/agent.ts
+++ b/src/typegate/src/runtimes/substantial/agent.ts
@@ -45,19 +45,7 @@ export class Agent {
   ) {}
 
   async schedule(input: AddScheduleInput) {
-    // FIXME:
-    // This function is triggered by the user (start, event, stop)
-    // Using async rust in here can be tricky, one issue for example is that
-    // concurrent calls fail silently without panics or even exceptions on the Redis Backend
-    // mutation {
-    //   one: start(..) # calls schedule(..)
-    //    ..
-    //   tenth: start(..) # calls schedule(..)
-    // }
-
     await Meta.substantial.storeAddSchedule(input);
-    // This delay is completely unrelated to the rust side and solves the issue
-    await sleep(100);
   }
 
   async log(runId: string, schedule: string, content: unknown) {

--- a/src/typegate/src/runtimes/substantial/workflow_worker_manager.ts
+++ b/src/typegate/src/runtimes/substantial/workflow_worker_manager.ts
@@ -197,7 +197,6 @@ export class WorkerManager {
     logger.info(`trigger ${type} for ${runId}`);
   }
 
-  /** Just as the name indicates, this will also decide to actually run it or not depending on the `storedRun` value  */
   triggerStart(
     name: string,
     runId: string,


### PR DESCRIPTION
Follow up of #863
When multiple start occurs for redis, some schedules can happen **exactly** at the same time resulting into the same identifier (and leading to an inconsistent state).

This solution simply combines the `schedule` with the run_id making it unique instead of using it as is.

```gql
mutation AllAtOnce {
  a: start_retry(kwargs: { .. }) # => calls add_schedule( ... date ...)
  b: start_retry(kwargs: { .. })
  c: start_retry(kwargs: { .. })
  d: start_retry(kwargs: { .. }) 
  e: start_retry(kwargs: { .. })
  f: start_retry(kwargs: { .. })
 # ..
}
```

#### Migration notes

None

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
