### PR TITLE
fix(ci): disable sccache when secrets not avail

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
         exclude-patterns:
           - "swc_*"
   - package-ecosystem: pip
-    directory: /typegraph
+    directory: /src/typegraph
     schedule:
       interval: monthly
     groups:
@@ -35,7 +35,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: npm
-    directory: /website
+    directory: /docs
     schedule:
       interval: monthly
     groups:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
       - synchronize
       - ready_for_review
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,18 +20,17 @@ env:
   GHJK_ENV: "ci"
   RUST_BACKTRACE: "full"
   DENO_DIR: deno-dir
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_BUCKET: "metacache"
-  SCCACHE_ENDPOINT: "https://s3.pub1.infomaniak.cloud"
-  SCCACHE_REGION: "us-east-1"
-  SCCACHE_S3_USE_SSL: "true"
-  SCCACHE_CACHE_SIZE: "30G"
-  AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
   # used by ghjk
   # TODO: add logic to setup-ghjk
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DOCKER_BUILD_NO_SUMMARY: true
+  SCCACHE_BUCKET: "metacache"
+  SCCACHE_ENDPOINT: "https://s3.pub1.infomaniak.cloud"
+  SCCACHE_REGION: "us-east-1"
+  SCCACHE_S3_USE_SSL: "true"
+  SCCACHE_CACHE_SIZE: "50G"
+  AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
 
 jobs:
   changes:
@@ -71,7 +70,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - if: ${{ env.AWS_ACCESS_KEY_ID }} != ""
+        name: Setup sccache secrets
+        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+        uses: mozilla-actions/sccache-action@v0.0.5
       - uses: metatypedev/setup-ghjk@318209a9d215f70716a4ac89dbeb9653a2deb8bc
       - shell: bash
         run: |
@@ -111,7 +114,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - if: ${{ env.AWS_ACCESS_KEY_ID }} != ""
+        name: Setup sccache secrets
+        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+        uses: mozilla-actions/sccache-action@v0.0.5
       - uses: metatypedev/setup-ghjk@318209a9d215f70716a4ac89dbeb9653a2deb8bc
         with:
           # temporary fix
@@ -223,7 +230,11 @@ jobs:
         with:
           detached: true
       - uses: dsherret/rust-toolchain-file@v1
-      - uses: mozilla-actions/sccache-action@v0.0.5
+      - if: ${{ env.AWS_ACCESS_KEY_ID }} != ""
+        name: Setup sccache secrets
+        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+        uses: mozilla-actions/sccache-action@v0.0.5
       # - name: Cache deno dir
       #  uses: actions/cache@v4
       #  with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,10 +71,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - if: ${{ env.AWS_ACCESS_KEY_ID != "" }}
+      - if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
         name: Setup sccache secrets
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != '' }}
         uses: mozilla-actions/sccache-action@v0.0.5
       - uses: metatypedev/setup-ghjk@318209a9d215f70716a4ac89dbeb9653a2deb8bc
       - shell: bash
@@ -115,10 +115,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != '' }}
         name: Setup sccache secrets
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != '' }}
         uses: mozilla-actions/sccache-action@v0.0.5
       - uses: metatypedev/setup-ghjk@318209a9d215f70716a4ac89dbeb9653a2deb8bc
         with:
@@ -231,10 +231,10 @@ jobs:
         with:
           detached: true
       - uses: dsherret/rust-toolchain-file@v1
-      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != '' }}
         name: Setup sccache secrets
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != '' }}
         uses: mozilla-actions/sccache-action@v0.0.5
       # - name: Cache deno dir
       #  uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,6 +256,8 @@ jobs:
           cache-disable: true
       - shell: bash
         run: |
+          # the big run
+
           # we don't want bash sub shells to do ghjk_reload
           # TODO: consider disabling ghjk_reload on non-interactive shells
           # by default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - if: ${{ env.AWS_ACCESS_KEY_ID }} != ""
+      - if: ${{ env.AWS_ACCESS_KEY_ID != "" }}
         name: Setup sccache secrets
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
-      - if: ${{ env.AWS_ACCESS_KEY_ID }} != ""
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
         name: Setup sccache secrets
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
@@ -231,7 +231,7 @@ jobs:
         with:
           detached: true
       - uses: dsherret/rust-toolchain-file@v1
-      - if: ${{ env.AWS_ACCESS_KEY_ID }} != ""
+      - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}
         name: Setup sccache secrets
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
       - if: ${{ env.AWS_ACCESS_KEY_ID  != "" }}


### PR DESCRIPTION
- Makes sccache optional so PRs from dependabot and forks can still run the test suite.
- Increases sccache allotment to 50g.