### PR TITLE
fix: speculative fix for `typegate_prisma_test.ts`

### DIFF
--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -964,6 +964,29 @@
               ],
               "allowedBuildDeps": "bciqek3tmrhm4iohl6tvdzlhxwhv7b52makvvgehltxv52d3l7rbki3y"
             },
+            "ghjkEnvProvInstSet___ci": {
+              "installs": [
+                "bciqbx637744bfiyvprs77xdnvdt7uuwmtlntfjpwmkda672gklkbpmi",
+                "bciqdtuhf425g6prb5fyupbcokttmkill6wyqk7bkphx3ueltl5mvu4q",
+                "bciqmvgsg7h3ohj3m7das4bznahgt6tyq7mamta3n2vorulqvml7mywq",
+                "bciqicdqw36v63cbrscwsgtu2htrmwmgtfoxexv4rx5d2y24vytxbuma",
+                "bciqe33uhsuaesrjk6luzxrbbimwg5ydt6x2lrieelwbr7aft4g2qwsy",
+                "bciqfjvqemdy7d6axvwkywcm6v66wogddvk7k6e6rps4e6zidkjvm4fy",
+                "bciqlubbahrp4pxohyffmn5yj52atjgmn5nxepmkdev6wtmvpbx7kr7y",
+                "bciqminqcmgw3fbbhibwc7tf6mrupttheic7kpiykadbowqmnzhmzo5a",
+                "bciqfpjzi6gguk7dafyicfjpzpwtybgyc2dsnxg2zxkcmyinzy7abpla",
+                "bciqkgncxbauys2qfguplxcz2auxrcyamj4b6htqk2fqvohfm3afd7sa",
+                "bciqihcmo6l5uwzih3e3ujc55curep4arfomo6rzkdsfim74unxexiqy",
+                "bciqezep4ufkgwesldlm5etyfkgdsiickfudx7cosydcz6xtgeorn2hy",
+                "bciqaixkkacuuligsvtjcfdfgjgl65owtyspiiljb3vmutlgymecsiwq",
+                "bciqlt27ioikxnpkqq37hma7ibn5e5wpzfarbvoh77zwdkarwghtvzxa",
+                "bciqojan3zglnfctnmqyxvnxaha46yrnlhj77j3kw4mxadvauqepqdba",
+                "bciqcnbruy2q6trpvia52n2yis4t27taoz4mxkeguqz5aif7ex6rp26y",
+                "bciqpu7gxs3zm7i4gwp3m3cfdxwz27ixvsykdnbxrl5m5mt3xbb3b4la",
+                "bciqjme7csfq43oenkrsakdhaha34hgy6vdwkfffki2ank3kf6mjcguq"
+              ],
+              "allowedBuildDeps": "bciqek3tmrhm4iohl6tvdzlhxwhv7b52makvvgehltxv52d3l7rbki3y"
+            },
             "ghjkEnvProvInstSet____ecma": {
               "installs": [
                 "bciqezep4ufkgwesldlm5etyfkgdsiickfudx7cosydcz6xtgeorn2hy",
@@ -989,28 +1012,6 @@
                 "bciqpu7gxs3zm7i4gwp3m3cfdxwz27ixvsykdnbxrl5m5mt3xbb3b4la",
                 "bciqjme7csfq43oenkrsakdhaha34hgy6vdwkfffki2ank3kf6mjcguq",
                 "bciqminqcmgw3fbbhibwc7tf6mrupttheic7kpiykadbowqmnzhmzo5a"
-              ],
-              "allowedBuildDeps": "bciqek3tmrhm4iohl6tvdzlhxwhv7b52makvvgehltxv52d3l7rbki3y"
-            },
-            "ghjkEnvProvInstSet___ci": {
-              "installs": [
-                "bciqdtuhf425g6prb5fyupbcokttmkill6wyqk7bkphx3ueltl5mvu4q",
-                "bciqmvgsg7h3ohj3m7das4bznahgt6tyq7mamta3n2vorulqvml7mywq",
-                "bciqicdqw36v63cbrscwsgtu2htrmwmgtfoxexv4rx5d2y24vytxbuma",
-                "bciqe33uhsuaesrjk6luzxrbbimwg5ydt6x2lrieelwbr7aft4g2qwsy",
-                "bciqfjvqemdy7d6axvwkywcm6v66wogddvk7k6e6rps4e6zidkjvm4fy",
-                "bciqlubbahrp4pxohyffmn5yj52atjgmn5nxepmkdev6wtmvpbx7kr7y",
-                "bciqminqcmgw3fbbhibwc7tf6mrupttheic7kpiykadbowqmnzhmzo5a",
-                "bciqfpjzi6gguk7dafyicfjpzpwtybgyc2dsnxg2zxkcmyinzy7abpla",
-                "bciqkgncxbauys2qfguplxcz2auxrcyamj4b6htqk2fqvohfm3afd7sa",
-                "bciqihcmo6l5uwzih3e3ujc55curep4arfomo6rzkdsfim74unxexiqy",
-                "bciqezep4ufkgwesldlm5etyfkgdsiickfudx7cosydcz6xtgeorn2hy",
-                "bciqaixkkacuuligsvtjcfdfgjgl65owtyspiiljb3vmutlgymecsiwq",
-                "bciqlt27ioikxnpkqq37hma7ibn5e5wpzfarbvoh77zwdkarwghtvzxa",
-                "bciqojan3zglnfctnmqyxvnxaha46yrnlhj77j3kw4mxadvauqepqdba",
-                "bciqcnbruy2q6trpvia52n2yis4t27taoz4mxkeguqz5aif7ex6rp26y",
-                "bciqpu7gxs3zm7i4gwp3m3cfdxwz27ixvsykdnbxrl5m5mt3xbb3b4la",
-                "bciqjme7csfq43oenkrsakdhaha34hgy6vdwkfffki2ank3kf6mjcguq"
               ],
               "allowedBuildDeps": "bciqek3tmrhm4iohl6tvdzlhxwhv7b52makvvgehltxv52d3l7rbki3y"
             },
@@ -1131,6 +1132,12 @@
         "id": "tasks",
         "config": {
           "tasks": {
+            "clean-node": {
+              "ty": "denoFile@v1",
+              "key": "clean-node",
+              "desc": "Remove all node_modules directories in tree and other js artifacts.",
+              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+            },
             "clean-rust": {
               "ty": "denoFile@v1",
               "key": "clean-rust",
@@ -1355,6 +1362,7 @@
             }
           },
           "tasksNamed": [
+            "clean-node",
             "clean-rust",
             "version-bump",
             "version-print",

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,3 +1,4 @@
+name: pre-commit auto-updater
 on:
   schedule:
     - cron: "0 2 1 * *"
@@ -10,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: browniebroke/pre-commit-autoupdate-action@main
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pre-commit-hooks

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,4 @@
+name: nightly docker builds
 on:
   schedule:
     - cron: "0 2 * * *"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,3 +1,5 @@
+name: pr title check
+run-name: checking pr title for ${{ github.event.pull_request.title || github.ref }}
 on:
   pull_request_target:
     types:

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -1,3 +1,5 @@
+name: publish website
+run-name: publish website jobs for ${{ github.ref }}
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,10 +321,13 @@ jobs:
 
           # avoid publishing pre-release versions as they don't
           # support it
-          [[ "$(ghjk x version-print)" != *-* ]] \
-            && ([ ${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ] \
-              && pnpm run vscode:publish -p ${{ secrets.AZURE_DEVOPS_TOKEN }} --skip-duplicate \
-              || pnpm run vscode:publish -p ${{ secrets.AZURE_DEVOPS_TOKEN }})
+          if [[ "$(ghjk x version-print)" != *-* ]]; then
+            if [ ${{ github.event_name == 'workflow_dispatch' && inputs.ovewriteArtifacts }} == 'true' ]; then
+              pnpm run vscode:publish -p ${{ secrets.AZURE_DEVOPS_TOKEN }} --skip-duplicate
+            else
+              pnpm run vscode:publish -p ${{ secrets.AZURE_DEVOPS_TOKEN }}
+            fi
+          fi
       - uses: svenstaro/upload-release-action@v2
         with:
           tag: ${{ steps.latest-tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: release jobs
+run-name: release jobs for ${{  github.ref }}
 on:
   workflow_dispatch:
     inputs:
@@ -352,7 +354,10 @@ jobs:
           ghjk x version-bump prerelease
           echo "version=$(ghjk x version-print)" >> $GITHUB_OUTPUT
           git cliff --output CHANGELOG.md
-      - uses: peter-evans/create-pull-request@v6
+          # exclude .ghjk from the changeset to avoid modifying
+          # the lockfile
+          git checkout -- .ghjk
+      - uses: peter-evans/create-pull-request@v7
         with:
           branch: bump-${{ steps.bump.outputs.version }}
           delete-branch: true
@@ -364,4 +369,4 @@ jobs:
           # on them, we create it as a draft PR 
           # the actions will then run when it's readied for review
           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          draft: always-true
+          draft: "always-true"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ env:
   SCCACHE_CACHE_SIZE: "50G"
   AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
-  TMATE_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
 
 jobs:
   changes:
@@ -105,7 +104,7 @@ jobs:
 
   lint-compat:
     needs: changes
-    if: ${{ env.TMATE_ENABLED == 'false' && needs.changes.outputs.full == 'true' }}
+    if: ${{ needs.changes.outputs.full == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.tmate_enabled) }}
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
@@ -150,7 +149,7 @@ jobs:
 
   test-website:
     needs: changes
-    if: ${{ env.TMATE_ENABLED == 'false' && needs.changes.outputs.website == 'true' }}
+    if: ${{ needs.changes.outputs.website == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.tmate_enabled) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -175,7 +174,7 @@ jobs:
 
   bulid-docker:
     needs: changes
-    if: ${{ env.TMATE_ENABLED == 'false' && needs.changes.outputs.typegate == 'true' }}
+    if: ${{ needs.changes.outputs.typegate == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.tmate_enabled) }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,13 @@
-name: Test Suite
-run-name: Test Suite for ${{ github.ref }}
+name: test suite
+run-name: test suite for ${{ github.event.pull_request.title || github.ref }}
 on:
   workflow_dispatch:
     inputs:
-      debug_enabled:
+      tmate_enabled:
         type: boolean
-        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
+        description: |
+          Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate). 
+          This disables all but the test-full jobs.
         required: false
         default: false
   push:
@@ -41,6 +43,7 @@ env:
   SCCACHE_CACHE_SIZE: "50G"
   AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
+  TMATE_ENABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
 
 jobs:
   changes:
@@ -102,7 +105,7 @@ jobs:
 
   lint-compat:
     needs: changes
-    if: ${{ needs.changes.outputs.full == 'true' }}
+    if: ${{ env.TMATE_ENABLED == 'false' && needs.changes.outputs.full == 'true' }}
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
@@ -147,7 +150,7 @@ jobs:
 
   test-website:
     needs: changes
-    if: ${{ needs.changes.outputs.website == 'true' }}
+    if: ${{ env.TMATE_ENABLED == 'false' && needs.changes.outputs.website == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -172,7 +175,7 @@ jobs:
 
   bulid-docker:
     needs: changes
-    if: ${{ needs.changes.outputs.typegate == 'true' }}
+    if: ${{ env.TMATE_ENABLED == 'false' && needs.changes.outputs.typegate == 'true' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -235,7 +238,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup tmate session
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
         uses: mxschmitt/action-tmate@v3
         with:
           detached: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6891,7 +6891,7 @@ dependencies = [
 
 [[package]]
 name = "meta-cli"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "actix",
  "assert_cmd",
@@ -6957,7 +6957,7 @@ dependencies = [
 
 [[package]]
 name = "metagen"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "color-eyre",
  "common",
@@ -7306,7 +7306,7 @@ dependencies = [
 
 [[package]]
 name = "mt_deno"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "deno",
@@ -11267,7 +11267,7 @@ dependencies = [
 
 [[package]]
 name = "substantial"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12755,7 +12755,7 @@ dependencies = [
 
 [[package]]
 name = "typegate"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "colored",
  "env_logger 0.11.0",
@@ -12768,7 +12768,7 @@ dependencies = [
 
 [[package]]
 name = "typegate_engine"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12813,7 +12813,7 @@ dependencies = [
 
 [[package]]
 name = "typegraph_core"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "color-eyre",
@@ -14566,7 +14566,7 @@ checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xtask"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 edition = "2021"
 
 [workspace.dependencies]

--- a/examples/templates/deno/api/example.ts
+++ b/examples/templates/deno/api/example.ts
@@ -1,6 +1,6 @@
-import { Policy, t, typegraph } from "jsr:@typegraph/sdk@0.5.0-rc.3/index.ts";
-import { PythonRuntime } from "jsr:@typegraph/sdk@0.5.0-rc.3/runtimes/python.ts";
-import { DenoRuntime } from "jsr:@typegraph/sdk@0.5.0-rc.3/runtimes/deno.ts";
+import { Policy, t, typegraph } from "jsr:@typegraph/sdk@0.5.0-rc.4/index.ts";
+import { PythonRuntime } from "jsr:@typegraph/sdk@0.5.0-rc.4/runtimes/python.ts";
+import { DenoRuntime } from "jsr:@typegraph/sdk@0.5.0-rc.4/runtimes/deno.ts";
 
 await typegraph("example", (g) => {
   const pub = Policy.public();

--- a/examples/templates/deno/compose.yml
+++ b/examples/templates/deno/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.5.0-rc.3
+    image: ghcr.io/metatypedev/typegate:v0.5.0-rc.4
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/compose.yml
+++ b/examples/templates/node/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.5.0-rc.3
+    image: ghcr.io/metatypedev/typegate:v0.5.0-rc.4
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/package.json
+++ b/examples/templates/node/package.json
@@ -6,7 +6,7 @@
     "dev": "MCLI_LOADER_CMD='npm x tsx' meta dev"
   },
   "dependencies": {
-    "@typegraph/sdk": "^0.5.0-rc.3"
+    "@typegraph/sdk": "^0.5.0-rc.4"
   },
   "devDependencies": {
     "tsx": "^3.13.0",

--- a/examples/templates/python/compose.yml
+++ b/examples/templates/python/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.5.0-rc.3
+    image: ghcr.io/metatypedev/typegate:v0.5.0-rc.4
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/python/pyproject.toml
+++ b/examples/templates/python/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "example"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 description = ""
 authors = []
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-typegraph = "0.5.0-rc.3"
+typegraph = "0.5.0-rc.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/ghjk.ts
+++ b/ghjk.ts
@@ -42,6 +42,7 @@ if (Deno.build.os == "linux" && !Deno.env.has("NO_MOLD")) {
   });
   env("dev").install(mold);
   env("oci").install(mold);
+  env("ci").install(mold);
 }
 
 env("_ecma").install(
@@ -176,4 +177,23 @@ task(
       $`cargo clean`.cwd("./examples/typegraphs/metagen/"),
     ]),
   { inherit: "_rust", desc: "Clean cache of all cargo workspaces in repo." },
+);
+
+task(
+  "clean-node",
+  ($) =>
+    $.co([
+      $.path("./docs/metatype.dev/node_modules"),
+      $.path("./docs/metatype.dev/build"),
+      $.path("./tests/e2e/nextjs/apollo/node_modules"),
+      $.path("./tests/runtimes/temporal/worker/node_modules"),
+    ].map(async (path) => {
+      if (await path.exists()) {
+        await path.remove({ recursive: true });
+      }
+    })),
+  {
+    inherit: "_ecma",
+    desc: "Remove all node_modules directories in tree and other js artifacts.",
+  },
 );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "metatype"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 description = ""
 authors = []
 

--- a/src/meta-lsp/package.json
+++ b/src/meta-lsp/package.json
@@ -4,7 +4,7 @@
   "description": "VSCode extension for Metatype support",
   "icon": "logo.png",
   "author": "Metatype Team",
-  "version": "0.5.0-rc.3",
+  "version": "0.5.0-rc.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/src/meta-lsp/ts-language-server/package.json
+++ b/src/meta-lsp/ts-language-server/package.json
@@ -2,7 +2,7 @@
   "name": "typegraph-ts-server",
   "description": "TypeScript language server for TypeGraph",
   "author": "Metatype Team",
-  "version": "0.5.0-rc.3",
+  "version": "0.5.0-rc.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/src/meta-lsp/vscode-metatype-support/package.json
+++ b/src/meta-lsp/vscode-metatype-support/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-metatype-support",
   "description": "VSCode extension for Metatype support",
   "author": "Metatype Team",
-  "version": "0.5.0-rc.3",
+  "version": "0.5.0-rc.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/metatypedev/metatype"

--- a/src/pyrt_wit_wire/pyproject.toml
+++ b/src/pyrt_wit_wire/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrt_wit_wire"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 description = "Wasm component implementing the PythonRuntime host using wit_wire protocol."
 license = "Elastic-2.0"
 readme = "README.md"

--- a/src/typegate/src/runtimes/wit_wire/mod.ts
+++ b/src/typegate/src/runtimes/wit_wire/mod.ts
@@ -9,7 +9,7 @@ import { getLogger } from "../../log.ts";
 
 const logger = getLogger(import.meta);
 
-const METATYPE_VERSION = "0.5.0-rc.3";
+const METATYPE_VERSION = "0.5.0-rc.4";
 
 export class WitWireMessenger {
   static async init(

--- a/src/typegraph/core/Cargo.toml
+++ b/src/typegraph/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typegraph_core"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 edition = "2021"
 
 [lib]

--- a/src/typegraph/core/src/global_store.rs
+++ b/src/typegraph/core/src/global_store.rs
@@ -107,7 +107,7 @@ const PREDEFINED_DENO_FUNCTIONS: &[&str] = &["identity", "true"];
 
 thread_local! {
     pub static STORE: RefCell<Store> = RefCell::new(Store::new());
-    pub static SDK_VERSION: String = "0.5.0-rc.3".to_owned();
+    pub static SDK_VERSION: String = "0.5.0-rc.4".to_owned();
 }
 
 fn with_store<T, F: FnOnce(&Store) -> T>(f: F) -> T {

--- a/src/typegraph/deno/deno.json
+++ b/src/typegraph/deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@typegraph/sdk",
-  "version": "0.5.0-rc.3",
+  "version": "0.5.0-rc.4",
   "publish": {
     "exclude": [
       "!src/gen",

--- a/src/typegraph/python/pyproject.toml
+++ b/src/typegraph/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typegraph"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 description = "Declarative API development platform. Build backend components with WASM, Typescript and Python, no matter where and how your (legacy) systems are."
 authors = ["Metatype Contributors <support@metatype.dev>"]
 license = "MPL-2.0"

--- a/src/typegraph/python/typegraph/__init__.py
+++ b/src/typegraph/python/typegraph/__init__.py
@@ -5,4 +5,4 @@ from typegraph.graph.typegraph import typegraph, Graph  # noqa
 from typegraph.policy import Policy  # noqa
 from typegraph import effects as fx  # noqa
 
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"

--- a/src/xtask/Cargo.toml
+++ b/src/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 edition = "2021"
 
 # this allows us to exclude the rust files

--- a/tests/e2e/published/published_test.ts
+++ b/tests/e2e/published/published_test.ts
@@ -43,14 +43,10 @@ const syncConfig = transformSyncConfig({
   s3_bucket: syncEnvs.SYNC_S3_BUCKET,
   s3_path_style: true,
 });
-console.log(syncConfig);
 
-// TODO remove after the next release
-// The build.rs script now uses a META_CMD env var allowing us
-// to use meta-old
-const disabled = [
-  "metagen-rs.ts",
-];
+// put here typegraphs that are to be excluded
+// from the test
+const disabled = [] as string[];
 
 async function checkMetaBin(path: typeof tempDir, version: string) {
   try {
@@ -410,7 +406,6 @@ typegraphs:
       await $`bash -c ${command}`
         .cwd(denoJsrDir)
         .env("PATH", `${metaBinDir}:${Deno.env.get("PATH")}`)
-        // FIXME: rename to deno.jsonc on bump 0.4.9
         .env("MCLI_LOADER_CMD", `deno run -A --config deno.json`)
         .env("RUST_LOG", "trace");
     });

--- a/tests/injection/injection_test.ts
+++ b/tests/injection/injection_test.ts
@@ -28,7 +28,7 @@ const schema = buildSchema(`
 `);
 
 const POSTGRES =
-  "postgresql://postgres:password@localhost:5432/db?schema=prisma";
+  "postgresql://postgres:password@localhost:5432/db?schema=injection_test_prisma";
 
 Meta.test("Injected values", async (t) => {
   const e = await t.engine("injection/injection.py", {

--- a/tests/metagen/__snapshots__/metagen_test.ts.snap
+++ b/tests/metagen/__snapshots__/metagen_test.ts.snap
@@ -448,7 +448,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.5.0-rc.3";
+        static MT_VERSION: &str = "0.5.0-rc.4";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }
@@ -1254,7 +1254,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.5.0-rc.3";
+        static MT_VERSION: &str = "0.5.0-rc.4";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }

--- a/tests/runtimes/typegate/__snapshots__/typegate_prisma_test.ts.snap
+++ b/tests/runtimes/typegate/__snapshots__/typegate_prisma_test.ts.snap
@@ -2,13 +2,320 @@ export const snapshot = {};
 
 snapshot[`typegate: find available operations 1`] = `
 {
-  errors: [
-    {
-      extensions: {},
-      locations: [],
-      message: "'config' not found at 'FindPrismaModels.findPrismaModels.fields.type', available names are: optional, title, type, enum, default, format, policies",
-      path: [],
-    },
-  ],
+  data: {
+    findPrismaModels: [
+      {
+        fields: [
+          {
+            as_id: true,
+            name: "id",
+            type: {
+              default: null,
+              enum: null,
+              format: "uuid",
+              optional: false,
+              policies: [],
+              title: "record_with_nested_count_id_string_uuid",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "name",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_string_filter_t0_string",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "age",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              policies: [],
+              title: "_prisma_integer_filter_t0_integer",
+              type: "integer",
+            },
+          },
+          {
+            as_id: false,
+            name: "createdAt",
+            type: {
+              default: null,
+              enum: null,
+              format: "date-time",
+              optional: false,
+              policies: [
+                '{"create":"__public"}',
+              ],
+              title: "record_cursor_t3_struct_createdAt_string_datetime",
+              type: "string",
+            },
+          },
+        ],
+        name: "record",
+        runtime: "prisma",
+      },
+      {
+        fields: [
+          {
+            as_id: true,
+            name: "id",
+            type: {
+              default: null,
+              enum: null,
+              format: "uuid",
+              optional: false,
+              policies: [],
+              title: "record_with_nested_count_id_string_uuid",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "name",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_string_filter_t0_string",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "age",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              policies: [],
+              title: "_prisma_integer_filter_t0_integer",
+              type: "integer",
+            },
+          },
+          {
+            as_id: false,
+            name: "createdAt",
+            type: {
+              default: null,
+              enum: null,
+              format: "date-time",
+              optional: false,
+              policies: [
+                '{"create":"__public"}',
+              ],
+              title: "record_cursor_t3_struct_createdAt_string_datetime",
+              type: "string",
+            },
+          },
+        ],
+        name: "renamed_record",
+        runtime: "prisma",
+      },
+      {
+        fields: [
+          {
+            as_id: true,
+            name: "id",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_integer_filter_t0_integer",
+              type: "integer",
+            },
+          },
+          {
+            as_id: false,
+            name: "identities",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "users_identities_user_identity_list",
+              type: "list",
+            },
+          },
+          {
+            as_id: false,
+            name: "email",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_string_filter_t0_string",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "name",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_string_filter_t0_string",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "messages",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "users_messages_messages_list",
+              type: "list",
+            },
+          },
+        ],
+        name: "users",
+        runtime: "prisma",
+      },
+      {
+        fields: [
+          {
+            as_id: true,
+            name: "id",
+            type: {
+              default: null,
+              enum: null,
+              format: "uuid",
+              optional: false,
+              policies: [],
+              title: "record_with_nested_count_id_string_uuid",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "provider",
+            type: {
+              default: null,
+              enum: [
+                '"github"',
+                '"google"',
+                '"facebook"',
+              ],
+              format: null,
+              optional: false,
+              policies: [],
+              title: "user_identity_create_input_excluding_rel_user_identity_users_provider_string_enum",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "identifier",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_string_filter_t0_string",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "user",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "users",
+              type: "object",
+            },
+          },
+        ],
+        name: "user_identity",
+        runtime: "prisma",
+      },
+      {
+        fields: [
+          {
+            as_id: true,
+            name: "id",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_integer_filter_t0_integer",
+              type: "integer",
+            },
+          },
+          {
+            as_id: false,
+            name: "time",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_integer_filter_t0_integer",
+              type: "integer",
+            },
+          },
+          {
+            as_id: false,
+            name: "message",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "_prisma_string_filter_t0_string",
+              type: "string",
+            },
+          },
+          {
+            as_id: false,
+            name: "sender",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: false,
+              policies: [],
+              title: "users",
+              type: "object",
+            },
+          },
+        ],
+        name: "messages",
+        runtime: "prisma",
+      },
+    ],
+  },
 }
 `;

--- a/tests/runtimes/typegate/__snapshots__/typegate_runtime_test.ts.snap
+++ b/tests/runtimes/typegate/__snapshots__/typegate_runtime_test.ts.snap
@@ -2,13 +2,549 @@ export const snapshot = {};
 
 snapshot[`typegate: find available operations 1`] = `
 {
-  errors: [
-    {
-      extensions: {},
-      locations: [],
-      message: "'config' not found at 'Q.findAvailableOperations.inputs.type', available names are: optional, title, type, enum, default, format, policies, fields",
-      path: [],
-    },
-  ],
+  data: {
+    findAvailableOperations: [
+      {
+        inputs: [
+          {
+            name: "where",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "record_query_where_unique_input",
+              type: "object",
+            },
+          },
+        ],
+        name: "findRecord",
+        output: {
+          default: null,
+          enum: null,
+          fields: [
+            {
+              subPath: [
+                "id",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: "uuid",
+                optional: false,
+                title: "record_with_nested_count_id_string_uuid",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "name",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_string_filter_t0_string",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "age",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: true,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+            {
+              subPath: [
+                "createdAt",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: "date-time",
+                optional: false,
+                title: "record_with_nested_count_createdAt_string_datetime",
+                type: "string",
+              },
+            },
+          ],
+          format: null,
+          optional: true,
+          title: "record_with_nested_count",
+          type: "object",
+        },
+        outputItem: null,
+      },
+      {
+        inputs: [
+          {
+            name: "where",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "record_query_where_input",
+              type: "object",
+            },
+          },
+          {
+            name: "orderBy",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "record_order_by",
+              type: "list",
+            },
+          },
+          {
+            name: "take",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "_take",
+              type: "integer",
+            },
+          },
+          {
+            name: "skip",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "_skip",
+              type: "integer",
+            },
+          },
+          {
+            name: "cursor",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "record_cursor",
+              type: "union",
+            },
+          },
+          {
+            name: "distinct",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "record_keys_union",
+              type: "list",
+            },
+          },
+        ],
+        name: "findManyRecords",
+        output: {
+          default: null,
+          enum: null,
+          fields: null,
+          format: null,
+          optional: false,
+          title: "root_findManyRecords_fn_output",
+          type: "list",
+        },
+        outputItem: {
+          default: null,
+          enum: null,
+          fields: [
+            {
+              subPath: [
+                "id",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: "uuid",
+                optional: false,
+                title: "record_with_nested_count_id_string_uuid",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "name",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_string_filter_t0_string",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "age",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: true,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+            {
+              subPath: [
+                "createdAt",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: "date-time",
+                optional: false,
+                title: "record_with_nested_count_createdAt_string_datetime",
+                type: "string",
+              },
+            },
+          ],
+          format: null,
+          optional: false,
+          title: "record_with_nested_count",
+          type: "object",
+        },
+      },
+      {
+        inputs: [
+          {
+            name: "where",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "users_query_where_unique_input",
+              type: "object",
+            },
+          },
+        ],
+        name: "findUniqueUser",
+        output: {
+          default: null,
+          enum: null,
+          fields: [
+            {
+              subPath: [
+                "id",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+            {
+              subPath: [
+                "identities",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "users_with_nested_count_identities_user_identity_with_nested_count_excluding_rel_user_identity_users_list",
+                type: "list",
+              },
+            },
+            {
+              subPath: [
+                "email",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_string_filter_t0_string",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "name",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_string_filter_t0_string",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "messages",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "users_with_nested_count_messages_messages_with_nested_count_excluding_messageSender_list",
+                type: "list",
+              },
+            },
+            {
+              subPath: [
+                "_count",
+                "identities",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: true,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+            {
+              subPath: [
+                "_count",
+                "messages",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: true,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+          ],
+          format: null,
+          optional: true,
+          title: "users_with_nested_count",
+          type: "object",
+        },
+        outputItem: null,
+      },
+      {
+        inputs: [
+          {
+            name: "where",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "messages_query_where_input",
+              type: "object",
+            },
+          },
+          {
+            name: "orderBy",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "messages_order_by",
+              type: "list",
+            },
+          },
+          {
+            name: "take",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "_take",
+              type: "integer",
+            },
+          },
+          {
+            name: "skip",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "_skip",
+              type: "integer",
+            },
+          },
+          {
+            name: "cursor",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "messages_cursor",
+              type: "union",
+            },
+          },
+          {
+            name: "distinct",
+            type: {
+              default: null,
+              enum: null,
+              format: null,
+              optional: true,
+              title: "messages_keys_union",
+              type: "list",
+            },
+          },
+        ],
+        name: "findMessages",
+        output: {
+          default: null,
+          enum: null,
+          fields: null,
+          format: null,
+          optional: false,
+          title: "root_findMessages_fn_output",
+          type: "list",
+        },
+        outputItem: {
+          default: null,
+          enum: null,
+          fields: [
+            {
+              subPath: [
+                "id",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+            {
+              subPath: [
+                "time",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+            {
+              subPath: [
+                "message",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_string_filter_t0_string",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "sender",
+                "id",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_integer_filter_t0_integer",
+                type: "integer",
+              },
+            },
+            {
+              subPath: [
+                "sender",
+                "identities",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "users_identities_user_identity_list",
+                type: "list",
+              },
+            },
+            {
+              subPath: [
+                "sender",
+                "email",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_string_filter_t0_string",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "sender",
+                "name",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "_prisma_string_filter_t0_string",
+                type: "string",
+              },
+            },
+            {
+              subPath: [
+                "sender",
+                "messages",
+              ],
+              termNode: {
+                default: null,
+                enum: null,
+                format: null,
+                optional: false,
+                title: "users_messages_messages_list",
+                type: "list",
+              },
+            },
+          ],
+          format: null,
+          optional: false,
+          title: "messages_with_nested_count",
+          type: "object",
+        },
+      },
+    ],
+  },
 }
 `;

--- a/tests/runtimes/typegate/typegate_prisma_test.ts
+++ b/tests/runtimes/typegate/typegate_prisma_test.ts
@@ -14,7 +14,7 @@ Meta.test({
   const prismaEngine = await t.engine("runtimes/prisma/prisma.py", {
     secrets: {
       POSTGRES:
-        "postgresql://postgres:password@localhost:5432/postgres?schema=prisma",
+        "postgresql://postgres:password@localhost:5432/postgres?schema=prisma_tg_test",
     },
   });
 
@@ -40,7 +40,6 @@ Meta.test({
               title
               type
               enum
-              config
               default
               format
               policies

--- a/tests/runtimes/typegate/typegate_runtime_test.ts
+++ b/tests/runtimes/typegate/typegate_runtime_test.ts
@@ -10,7 +10,7 @@ Meta.test({
   const prismaEngine = await t.engine("runtimes/prisma/prisma.py", {
     secrets: {
       POSTGRES:
-        "postgresql://postgres:password@localhost:5432/postgres?schema=prisma",
+        "postgresql://postgres:password@localhost:5432/postgres?schema=prisma_rt_test",
     },
   });
 
@@ -29,7 +29,6 @@ Meta.test({
         title
         type
         enum
-        config
         default
         format
       }

--- a/tests/runtimes/wasm_reflected/rust/Cargo.toml
+++ b/tests/runtimes/wasm_reflected/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 edition = "2021"
 
 [lib]

--- a/tools/consts.ts
+++ b/tools/consts.ts
@@ -1,8 +1,8 @@
 // Copyright Metatype OÜ, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
-export const METATYPE_VERSION = "0.5.0-rc.3";
-export const PUBLISHED_VERSION = "0.5.0-rc.2";
+export const METATYPE_VERSION = "0.5.0-rc.4";
+export const PUBLISHED_VERSION = "0.5.0-rc.3";
 export const GHJK_VERSION = "v0.2.1";
 export const GHJK_ACTION_VERSION = "318209a9d215f70716a4ac89dbeb9653a2deb8bc";
 export const RUST_VERSION = "1.80.1";


### PR DESCRIPTION
- Assigns special schemas for each test that relies on the `runtimes/prisma/prisma.py` typegraph.
- Bumps version tag to 0.5.0-rc4
- Fixes issues in release pipeline
- Disables all but the `test-full` job when the test pipeline is run with tmate enabled. 

The flakeout of `typegate_prisma_test.ts` has proved difficult to recreate. Looking at the code and going from recent similar cases, I suspect it happens due to the old code reusing the same pg schema for multiple tests. Assigning special schemas for each tests should hopefully help.


#### Migration notes

N/A

---

- [x] The change comes with new or modified tests
