### PR TITLE
fix(typegraph): send rpc message in chunks in the TS typegraph client 

### DIFF
--- a/examples/typegraphs/metagen/rs/fdk.rs
+++ b/examples/typegraphs/metagen/rs/fdk.rs
@@ -109,7 +109,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.5.0-rc.3";
+        static MT_VERSION: &str = "0.5.0-rc.4";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }

--- a/src/meta-cli/src/cli/gen.rs
+++ b/src/meta-cli/src/cli/gen.rs
@@ -158,7 +158,7 @@ impl InputResolver for MetagenCtx {
                     .join(path)
                     .canonicalize()
                     .wrap_err("unable to canonicalize typegraph path, make sure it exists")?;
-                let raw = load_tg_at(config, path, name.as_deref()).await?;
+                let raw = load_tg_at(config, path, name.as_deref(), &self.dir).await?;
                 GeneratorInputResolved::TypegraphFromTypegate { raw }
             }
             GeneratorInputOrder::LoadFdkTemplate {
@@ -177,6 +177,7 @@ async fn load_tg_at(
     config: Arc<Config>,
     path: PathBuf,
     name: Option<&str>,
+    dir: &Path,
 ) -> anyhow::Result<Box<Typegraph>> {
     let console = ConsoleActor::new(Arc::clone(&config)).start();
 
@@ -185,7 +186,7 @@ async fn load_tg_at(
         config.clone(),
         SerializeActionGenerator::new(
             config_dir.clone(),
-            config_dir, // TODO cwd
+            dir.into(),
             config
                 .prisma_migrations_base_dir(PathOption::Absolute)
                 .into(),
@@ -200,7 +201,7 @@ async fn load_tg_at(
     let mut tgs = report.into_typegraphs()?;
 
     if tgs.is_empty() {
-        bail!("not typegraphs loaded from path at {path:?}")
+        bail!("no typegraphs loaded from path at {path:?}")
     }
     let tg = if let Some(tg_name) = name {
         if let Some(idx) = tgs.iter().position(|tg| tg.name().unwrap() == tg_name) {

--- a/src/meta-cli/src/deploy/actors/task_io.rs
+++ b/src/meta-cli/src/deploy/actors/task_io.rs
@@ -218,7 +218,7 @@ impl<A: TaskAction + 'static> TaskIoActor<A> {
             Err(err) => {
                 self.console
                     .error(format!("{scope} failed to parse JSON-RPC message: {err}"));
-                // TODO send JSON-RPC error response (-32700)
+                // TODO cancel task?
                 return;
             }
         };
@@ -231,7 +231,7 @@ impl<A: TaskAction + 'static> TaskIoActor<A> {
                     console.error(format!(
                         "{scope} failed to validate JSON-RPC request: {err}"
                     ));
-                    // TODO send JSON-RPC error response (-32600)
+                    // TODO cancel task?
                 }
             }
         } else {
@@ -244,7 +244,7 @@ impl<A: TaskAction + 'static> TaskIoActor<A> {
                     console.error(format!(
                         "{scope} failed to validate JSON-RPC notification: {err}"
                     ));
-                    // TODO send JSON-RPC error response (-32600)
+                    // TODO cancel task?
                 }
             };
         }
@@ -281,7 +281,7 @@ impl<A: TaskAction + 'static> TaskIoActor<A> {
                         console.error(format!(
                             "{scope} failed to validate JSON-RPC notification (success): {err}"
                         ));
-                        // TODO send JSON-RPC error response (-32600)
+                        // TODO cancel task?
                         return;
                     }
                 };
@@ -294,7 +294,7 @@ impl<A: TaskAction + 'static> TaskIoActor<A> {
                         console.error(format!(
                             "{scope} failed to validate JSON-RPC notification (failure): {err}"
                         ));
-                        // TODO send JSON-RPC error response (-32600)
+                        // TODO cancel task?
                         return;
                     }
                 };

--- a/src/meta-cli/src/deploy/actors/task_io.rs
+++ b/src/meta-cli/src/deploy/actors/task_io.rs
@@ -236,7 +236,6 @@ impl<A: TaskAction + 'static> TaskIoActor<A> {
             }
         } else {
             // JSON-RPC notification
-
             match serde_json::from_value::<RpcNotificationMessage>(message)
                 .map(|msg| msg.notification)
             {

--- a/src/meta-cli/src/deploy/actors/task_manager.rs
+++ b/src/meta-cli/src/deploy/actors/task_manager.rs
@@ -9,6 +9,7 @@ use crate::{config::Config, interlude::*};
 use colored::OwoColorize;
 use futures::channel::oneshot;
 use indexmap::IndexMap;
+use pathdiff::diff_paths;
 use signal_handler::set_stop_recipient;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -205,9 +206,16 @@ impl<A: TaskAction + 'static> TaskManagerInit<A> {
     ) -> Option<Addr<WatcherActor<A>>> {
         match &self.task_source {
             TaskSource::Static(paths) => {
+                let working_dir = self
+                    .action_generator
+                    .get_shared_config()
+                    .working_dir
+                    .clone();
                 for path in paths {
+                    let relative_path = diff_paths(path, &working_dir);
                     addr.do_send(AddTask {
-                        task_ref: task_generator.generate(path.clone().into(), 0),
+                        task_ref: task_generator
+                            .generate(relative_path.unwrap_or_else(|| path.clone()).into(), 0),
                         reason: TaskReason::User,
                     });
                 }

--- a/src/typegraph/deno/src/io.ts
+++ b/src/typegraph/deno/src/io.ts
@@ -133,7 +133,7 @@ const rpcCall = (() => {
       params,
     });
 
-    process.stdout.write(`jsonrpc: ${rpcMessage}\n`);
+    writeRpcMessage(rpcMessage);
     return responseReader.read(rpcId);
   };
 })();

--- a/src/typegraph/deno/src/io.ts
+++ b/src/typegraph/deno/src/io.ts
@@ -10,8 +10,8 @@ import process from "node:process";
 const JSONRPC_VERSION = "2.0";
 
 function writeRpcMessage(message: string) {
-  // split into 32-kibibyte chunks
-  const chunkSize = 32768;
+  // split into 32-KiB chunks
+  const chunkSize = 32758; // 32 KiB - 10 bytes for "jsonrpc^: " or "jsonrpc$: "
   for (let i = 0; i < message.length; i += chunkSize) {
     const chunk = message.slice(i, i + chunkSize);
     if (i + chunkSize < message.length) {

--- a/src/typegraph/deno/src/io.ts
+++ b/src/typegraph/deno/src/io.ts
@@ -7,6 +7,38 @@ import process from "node:process";
  * see: module level documentation `meta-cli/src/deploy/actors/task.rs`
  */
 
+const JSONRPC_VERSION = "2.0";
+
+function writeRpcMessage(message: string) {
+  // split into 32-kibibyte chunks
+  const chunkSize = 32768;
+  for (let i = 0; i < message.length; i += chunkSize) {
+    const chunk = message.slice(i, i + chunkSize);
+    if (i + chunkSize < message.length) {
+      process.stdout.write(`jsonrpc^: ${chunk}\n`);
+      continue;
+    }
+    process.stdout.write(`jsonrpc$: ${message.slice(i, i + chunkSize)}\n`);
+  }
+}
+
+type RpcNotificationMethod =
+  | "Debug"
+  | "Info"
+  | "Warning"
+  | "Error"
+  | "Success"
+  | "Failure";
+
+const rpcNotify = (method: RpcNotificationMethod, params: any = null) => {
+  const message = JSON.stringify({
+    jsonrpc: JSONRPC_VERSION,
+    method,
+    params,
+  });
+  writeRpcMessage(message);
+};
+
 function getOutput(args: any[]) {
   return args
     .map((arg) => {
@@ -23,28 +55,28 @@ function getOutput(args: any[]) {
 
 export const log = {
   debug(...args: any[]) {
-    const output = getOutput(args);
-    process.stdout.write(`debug: ${output}\n`);
+    rpcNotify("Debug", { message: getOutput(args) });
   },
   info(...args: any[]) {
-    const output = getOutput(args);
-    process.stdout.write(`info: ${output}\n`);
+    rpcNotify("Info", { message: getOutput(args) });
   },
   warn(...args: any[]) {
-    const output = getOutput(args);
-    process.stdout.write(`warning: ${output}\n`);
+    rpcNotify("Warning", { message: getOutput(args) });
   },
   error(...args: any[]) {
-    const output = getOutput(args);
-    process.stdout.write(`error: ${output}\n`);
+    rpcNotify("Error", { message: getOutput(args) });
   },
 
   failure(data: any) {
-    process.stdout.write(`failure: ${JSON.stringify(data)}\n`);
+    rpcNotify("Failure", { data: data });
   },
   success(data: any, noEncode = false) {
-    const encoded = noEncode ? data : JSON.stringify(data);
-    process.stdout.write(`success: ${encoded}\n`);
+    // TODO why no encode??
+    if (noEncode) {
+      rpcNotify("Success", { data: JSON.parse(data) });
+    } else {
+      rpcNotify("Success", { data: data });
+    }
   },
 };
 
@@ -88,8 +120,6 @@ class RpcResponseReader {
     });
   }
 }
-
-const JSONRPC_VERSION = "2.0";
 
 const rpcCall = (() => {
   const responseReader = new RpcResponseReader();

--- a/src/typegraph/deno/src/io.ts
+++ b/src/typegraph/deno/src/io.ts
@@ -71,7 +71,6 @@ export const log = {
     rpcNotify("Failure", { data: data });
   },
   success(data: any, noEncode = false) {
-    // TODO why no encode??
     if (noEncode) {
       rpcNotify("Success", { data: JSON.parse(data) });
     } else {

--- a/src/typegraph/python/typegraph/io.py
+++ b/src/typegraph/python/typegraph/io.py
@@ -12,6 +12,22 @@ import json
 _JSONRPC_VERSION = "2.0"
 
 
+def write_rpc_message(message: str):
+    # we do not chunk the message as Python's print function supports long lines
+    print(f"jsonrpc$: {message}")
+
+
+def rpc_notify(method: str, params: Any):
+    message = json.dumps(
+        {
+            "jsonrpc": _JSONRPC_VERSION,
+            "method": method,
+            "params": params,
+        }
+    )
+    write_rpc_message(message)
+
+
 class Log:
     @staticmethod
     def __format(*largs: Any):
@@ -19,30 +35,31 @@ class Log:
 
     @staticmethod
     def debug(*largs: Any):
-        print("debug:", Log.__format(*largs))
+        rpc_notify("Debug", {"message": Log.__format(*largs)})
 
     @staticmethod
     def info(*largs: Any):
-        print("info:", Log.__format(*largs))
+        rpc_notify("Info", {"message": Log.__format(*largs)})
 
     @staticmethod
     def warn(*largs: Any):
-        print("warning:", Log.__format(*largs))
+        rpc_notify("Warning", {"message": Log.__format(*largs)})
 
     @staticmethod
     def error(*largs: Any):
-        print("error:", Log.__format(*largs))
+        rpc_notify("Error", {"message": Log.__format(*largs)})
 
     @staticmethod
     def failure(data: Any):
-        print("failure:", json.dumps(data))
+        rpc_notify("Failure", {"data": data})
 
     @staticmethod
     def success(data: Any, noencode: bool = False):
         if noencode:
-            print("success:", data)
+            parsed = json.loads(data)
+            rpc_notify("Success", {"data": parsed})
         else:
-            print("success:", json.dumps(data))
+            rpc_notify("Success", {"data": data})
 
 
 class _RpcResponseReader:
@@ -90,7 +107,7 @@ class _RpcCall:
             }
         )
 
-        print(f"jsonrpc: {rpc_message}")
+        write_rpc_message(rpc_message)
         return cls.response_reader.read(rpc_id)
 
 


### PR DESCRIPTION
- Send the JSON-RPC message is chunks in the TypeScript typegraph client to prevent reaching the line size limit for stdout. Note: we could not reproduce the issue locally as it only occurs when using the published package for Node.js.
- Use JSON-RPC notification for logging and report from the typegraph clients.
- Other changes:
  - Use relative paths for static task sources in the CLI;
  - Fix TODO in `meta gen`: pass the working directory on the `working_dir` param of `SerializeActionGenerator::new`.

<!-- 2. Explain WHY the change cannot be made simpler -->



<!-- 3. Explain HOW users should update their code -->

#### Migration notes
_N/A_

---

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
