### PR TITLE
fix: Remove prisma count

### DIFF
--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -1092,25 +1092,25 @@
               "ty": "denoFile@v1",
               "key": "dev-gate6",
               "desc": "Launch the typegate from a locally found meta bin.",
-              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
+              "envKey": "bciqcljozrbuwh7aum6v6soif6qr2nvpwr7gbyxrmob3ybh4bsxpqfyy"
             },
             "dev-gate5": {
               "ty": "denoFile@v1",
               "key": "dev-gate5",
               "desc": "Launch the typegate from the latests published image.",
-              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
+              "envKey": "bciqcljozrbuwh7aum6v6soif6qr2nvpwr7gbyxrmob3ybh4bsxpqfyy"
             },
             "dev-gate4": {
               "ty": "denoFile@v1",
               "key": "dev-gate4",
               "desc": "Launch the typegate from the locally built typegate image.",
-              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
+              "envKey": "bciqcljozrbuwh7aum6v6soif6qr2nvpwr7gbyxrmob3ybh4bsxpqfyy"
             },
             "dev-gate3": {
               "ty": "denoFile@v1",
               "key": "dev-gate3",
               "desc": "Launch the typegate from meta-cli cmd.",
-              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
+              "envKey": "bciqcljozrbuwh7aum6v6soif6qr2nvpwr7gbyxrmob3ybh4bsxpqfyy"
             },
             "dev-gate2": {
               "ty": "denoFile@v1",
@@ -1122,7 +1122,7 @@
               "ty": "denoFile@v1",
               "key": "dev-gate1",
               "desc": "Launch the typegate in single-instance mode.",
-              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
+              "envKey": "bciqcljozrbuwh7aum6v6soif6qr2nvpwr7gbyxrmob3ybh4bsxpqfyy"
             },
             "dev-eg-tgraphs": {
               "ty": "denoFile@v1",
@@ -1573,7 +1573,7 @@
                 }
               ]
             },
-            "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y": {
+            "bciqcljozrbuwh7aum6v6soif6qr2nvpwr7gbyxrmob3ybh4bsxpqfyy": {
               "provides": [
                 {
                   "ty": "posix.envVar",
@@ -1633,7 +1633,7 @@
                 {
                   "ty": "posix.envVar",
                   "key": "TG_PORT",
-                  "val": "7890"
+                  "val": "7891"
                 },
                 {
                   "ty": "ghjk.ports.InstallSetRef",

--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -966,106 +966,106 @@
               "ty": "denoFile@v1",
               "key": "clean-node",
               "desc": "Remove all node_modules directories in tree and other js artifacts.",
-              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+              "envKey": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a"
             },
             "clean-rust": {
               "ty": "denoFile@v1",
               "key": "clean-rust",
               "desc": "Clean cache of all cargo workspaces in repo.",
-              "envKey": "bciqp6dugoxl3avklj2uwl77sfbiixbo2vzduaohoeusqjktc63dshzy"
+              "envKey": "bciqof7ogmp2lx2bzmkbrtmdmrmj7seytb6bl2sb4uhnsxkf5v24m75i"
             },
             "version-bump": {
               "ty": "denoFile@v1",
               "key": "version-bump",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "version-print": {
               "ty": "denoFile@v1",
               "key": "version-print",
               "desc": "Print $METATYPE_VERSION",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "test-lsp": {
               "ty": "denoFile@v1",
               "key": "test-lsp",
-              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+              "envKey": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a"
             },
             "test-rust": {
               "ty": "denoFile@v1",
               "key": "test-rust",
-              "envKey": "bciqcctzik23xr7nadelnnusqesxpvkau6f5inuhqaggouuczqgevxfq"
+              "envKey": "bciqc4wyajjcgt24t2uhjf7zkzhq6gy2iektcnmjrnrkj3u2mhlzhcma"
             },
             "test-website": {
               "ty": "denoFile@v1",
               "key": "test-website",
               "workingDir": "./docs/metatype.dev",
-              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+              "envKey": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a"
             },
             "test-e2e": {
               "ty": "denoFile@v1",
               "key": "test-e2e",
               "desc": "Shorthand for `tools/test.ts`",
-              "envKey": "bciqniih3pp536jhouqduhilkpdas6uoesz6b2ckvstng6t7rlxz7jjq"
+              "envKey": "bciqbjavwy7rbire3zwlpgo2ifwzgnm6ywxqswnh6qxezwuvc4bqhrca"
             },
             "lock-sed": {
               "ty": "denoFile@v1",
               "key": "lock-sed",
               "desc": "Update versions",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "lint-deno": {
               "ty": "denoFile@v1",
               "key": "lint-deno",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "lint-udeps": {
               "ty": "denoFile@v1",
               "key": "lint-udeps",
               "desc": "Check for unused cargo depenencies",
-              "envKey": "bciqhppphe2gyonum75xce4zlcglvswdte32hlpm6eulnwtuzc665tgq"
+              "envKey": "bciqkfzynmgivxtsz2qoytkbvn4rwxe3ngzodvhxvvlqqlt4b62miuyy"
             },
             "install-wasi-adapter": {
               "ty": "denoFile@v1",
               "key": "install-wasi-adapter",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "install-lsp": {
               "ty": "denoFile@v1",
               "key": "install-lsp",
-              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+              "envKey": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a"
             },
             "install-website": {
               "ty": "denoFile@v1",
               "key": "install-website",
-              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+              "envKey": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a"
             },
             "install-ts": {
               "ty": "denoFile@v1",
               "key": "install-ts",
-              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+              "envKey": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a"
             },
             "install-py": {
               "ty": "denoFile@v1",
               "key": "install-py",
-              "envKey": "bciqea2qrlw3rmfp2edgo2o7utf5ahjpa4r6y4nrw2pbmqm2g2rabviy"
+              "envKey": "bciqovedn2du5h56q6t4nolxi47yddf76bgaobbexfcxsjyuzj465tri"
             },
             "install-sys": {
               "ty": "denoFile@v1",
               "key": "install-sys",
               "desc": "Print a command you can use to install system items",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "gen-subs-protoc": {
               "ty": "denoFile@v1",
               "key": "gen-subs-protoc",
               "workingDir": "src/substantial",
               "desc": "Regenerate substantial types",
-              "envKey": "bciqpunhgxn3npmv6lwplhckwyn5zls7crj3vodn6we6ihuhu4y7djcy"
+              "envKey": "bciqifnqvvzjvxnddwvnxomtrjtti2f5iefaj2l3aoz732lrnmg4utvq"
             },
             "gen-pyrt-bind": {
               "ty": "denoFile@v1",
               "key": "gen-pyrt-bind",
-              "envKey": "bciqdpiup27tflfkq26oirbutkz53wrp34entiq423upf47za7zoq4za"
+              "envKey": "bciqa4zotbgmulpg3cutg6nu3ptq5merbt2gbf5a26twwcfe7djxchsi"
             },
             "build-pyrt": {
               "ty": "denoFile@v1",
@@ -1073,84 +1073,84 @@
               "dependsOn": [
                 "gen-pyrt-bind"
               ],
-              "envKey": "bciqdpiup27tflfkq26oirbutkz53wrp34entiq423upf47za7zoq4za"
+              "envKey": "bciqa4zotbgmulpg3cutg6nu3ptq5merbt2gbf5a26twwcfe7djxchsi"
             },
             "fetch-deno": {
               "ty": "denoFile@v1",
               "key": "fetch-deno",
               "desc": "Cache remote deno modules.",
-              "envKey": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma"
+              "envKey": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a"
             },
             "dev-website": {
               "ty": "denoFile@v1",
               "key": "dev-website",
               "workingDir": "./docs/metatype.dev",
               "desc": "Launch the website",
-              "envKey": "bciqmkhbtdu3anjuk2oyegq2sb3ogzeljgadytenbtt6izyzfqinxdna"
+              "envKey": "bciqgrksux7l63plnyfryiqoth7wghawzcxmptsdw7qlbxpeytpot6fq"
             },
             "dev-gate6": {
               "ty": "denoFile@v1",
               "key": "dev-gate6",
               "desc": "Launch the typegate from a locally found meta bin.",
-              "envKey": "bciqd6zbaarkdhf3u74bcxlzvmi2ywirr2sjtrzh7thrbnc3ijz3sq4q"
+              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
             },
             "dev-gate5": {
               "ty": "denoFile@v1",
               "key": "dev-gate5",
               "desc": "Launch the typegate from the latests published image.",
-              "envKey": "bciqd6zbaarkdhf3u74bcxlzvmi2ywirr2sjtrzh7thrbnc3ijz3sq4q"
+              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
             },
             "dev-gate4": {
               "ty": "denoFile@v1",
               "key": "dev-gate4",
               "desc": "Launch the typegate from the locally built typegate image.",
-              "envKey": "bciqd6zbaarkdhf3u74bcxlzvmi2ywirr2sjtrzh7thrbnc3ijz3sq4q"
+              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
             },
             "dev-gate3": {
               "ty": "denoFile@v1",
               "key": "dev-gate3",
               "desc": "Launch the typegate from meta-cli cmd.",
-              "envKey": "bciqd6zbaarkdhf3u74bcxlzvmi2ywirr2sjtrzh7thrbnc3ijz3sq4q"
+              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
             },
             "dev-gate2": {
               "ty": "denoFile@v1",
               "key": "dev-gate2",
               "desc": "Launch the typegate in sync mode.",
-              "envKey": "bciqgjkrsledgw64yjp4hkj2lpf26pnamtuhsyho7bd55742yprtyv4y"
+              "envKey": "bciqgfe63ayh7e7kzg4f47bmaleew7jcdukchs3cg45tvdiwoxotxzfy"
             },
             "dev-gate1": {
               "ty": "denoFile@v1",
               "key": "dev-gate1",
               "desc": "Launch the typegate in single-instance mode.",
-              "envKey": "bciqd6zbaarkdhf3u74bcxlzvmi2ywirr2sjtrzh7thrbnc3ijz3sq4q"
+              "envKey": "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y"
             },
             "dev-eg-tgraphs": {
               "ty": "denoFile@v1",
               "key": "dev-eg-tgraphs",
               "desc": "meta dev example/typegraphs",
-              "envKey": "bciqns7jnxsdugrzboolqtwsh4ohiq5u3p46dezn7huqgo5rq4ps2gja"
+              "envKey": "bciqlb6jtozvezqdgkfkfxlztreqi2j6lxqdk5zvvlbc2o5ka7qtljji"
             },
             "dev-compose": {
               "ty": "denoFile@v1",
               "key": "dev-compose",
               "desc": "Wrapper around docker compose to manage runtime dependencies",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "dev": {
               "ty": "denoFile@v1",
               "key": "dev",
               "desc": "Execute tools/*.ts scripts.",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "build-tgraph-ts-jsr": {
               "ty": "denoFile@v1",
               "key": "build-tgraph-ts-jsr",
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "build-tgraph-core": {
               "ty": "denoFile@v1",
               "key": "build-tgraph-core",
-              "envKey": "bciqgqffklh7r5setenk7bkrqoyingrbbjbrcj4jka3rttr56ybxruqi"
+              "envKey": "bciqkazb54zk6wdbxpizobukdsz5ruxrtlkf6bfwvctdiwzq6lz7unsq"
             },
             "build-tgraph-py": {
               "ty": "denoFile@v1",
@@ -1158,7 +1158,7 @@
               "dependsOn": [
                 "build-tgraph-core"
               ],
-              "envKey": "bciqmqhamsvcr6i7ol37s5kizxnoawcecho4kzqiwxgodztarzdapawa"
+              "envKey": "bciqly23hzeass3kah6rgds4wyqenzsrcmtru7nsvht7t23dsjvgynyi"
             },
             "build-tgraph-ts": {
               "ty": "denoFile@v1",
@@ -1166,7 +1166,7 @@
               "dependsOn": [
                 "build-tgraph-core"
               ],
-              "envKey": "bciqp4x2tqplttorqy7ixw4rltvd7i5dknke6f3ba3uzbgymrp3s7aya"
+              "envKey": "bciqasv6wmp2sicgg5dbbjxiv5ojm3t3ga3e75y5igacjq4zureobu6q"
             },
             "build-tgraph-ts-node": {
               "ty": "denoFile@v1",
@@ -1174,7 +1174,7 @@
               "dependsOn": [
                 "build-tgraph-ts"
               ],
-              "envKey": "bciqp4x2tqplttorqy7ixw4rltvd7i5dknke6f3ba3uzbgymrp3s7aya"
+              "envKey": "bciqasv6wmp2sicgg5dbbjxiv5ojm3t3ga3e75y5igacjq4zureobu6q"
             },
             "build-tgraph": {
               "ty": "denoFile@v1",
@@ -1183,12 +1183,12 @@
                 "build-tgraph-py",
                 "build-tgraph-ts-node"
               ],
-              "envKey": "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq"
+              "envKey": "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa"
             },
             "build-sys-tgraphs": {
               "ty": "denoFile@v1",
               "key": "build-sys-tgraphs",
-              "envKey": "bciqont2hfpi4wf7ul7acfxfdzwt4q4xm4sqpt2x6rvfc3kxxrtguj6i"
+              "envKey": "bciqeby2w3rophwmqawnkmicgymgudbcdqjirrz3r7oltu44uqp4emsq"
             }
           },
           "tasksNamed": [
@@ -1237,13 +1237,13 @@
         "id": "envs",
         "config": {
           "envs": {
-            "bciqiaaqxx3azvrkvlj2eknjj6awsczu4gdcohccrvjpwk3vmkrnyfpi": {
+            "bciqacae7toziicv72e7ugl6kuv25bbxl5ygu5dugtczoojzqkwayp6q": {
               "desc": "the default default environment.",
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1271,12 +1271,12 @@
                 }
               ]
             },
-            "bciqipocpp2avwxmyj6rxrkpukmkjgwtzafiwnqwtlum62mho2mtcbgq": {
+            "bciqkxvhlk6wifuxken6emvhj2cki7tw5ygccar6qq4vbartg776akqa": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1304,12 +1304,12 @@
                 }
               ]
             },
-            "bciqhppphe2gyonum75xce4zlcglvswdte32hlpm6eulnwtuzc665tgq": {
+            "bciqkfzynmgivxtsz2qoytkbvn4rwxe3ngzodvhxvvlqqlt4b62miuyy": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1337,12 +1337,12 @@
                 }
               ]
             },
-            "bciqdpiup27tflfkq26oirbutkz53wrp34entiq423upf47za7zoq4za": {
+            "bciqa4zotbgmulpg3cutg6nu3ptq5merbt2gbf5a26twwcfe7djxchsi": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1370,12 +1370,12 @@
                 }
               ]
             },
-            "bciqea2qrlw3rmfp2edgo2o7utf5ahjpa4r6y4nrw2pbmqm2g2rabviy": {
+            "bciqovedn2du5h56q6t4nolxi47yddf76bgaobbexfcxsjyuzj465tri": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1403,12 +1403,12 @@
                 }
               ]
             },
-            "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma": {
+            "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1436,12 +1436,12 @@
                 }
               ]
             },
-            "bciqmkhbtdu3anjuk2oyegq2sb3ogzeljgadytenbtt6izyzfqinxdna": {
+            "bciqgrksux7l63plnyfryiqoth7wghawzcxmptsdw7qlbxpeytpot6fq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1474,12 +1474,12 @@
                 }
               ]
             },
-            "bciqp6dugoxl3avklj2uwl77sfbiixbo2vzduaohoeusqjktc63dshzy": {
+            "bciqof7ogmp2lx2bzmkbrtmdmrmj7seytb6bl2sb4uhnsxkf5v24m75i": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1507,12 +1507,12 @@
                 }
               ]
             },
-            "bciqcctzik23xr7nadelnnusqesxpvkau6f5inuhqaggouuczqgevxfq": {
+            "bciqc4wyajjcgt24t2uhjf7zkzhq6gy2iektcnmjrnrkj3u2mhlzhcma": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1540,12 +1540,12 @@
                 }
               ]
             },
-            "bciqpunhgxn3npmv6lwplhckwyn5zls7crj3vodn6we6ihuhu4y7djcy": {
+            "bciqifnqvvzjvxnddwvnxomtrjtti2f5iefaj2l3aoz732lrnmg4utvq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1573,12 +1573,12 @@
                 }
               ]
             },
-            "bciqd6zbaarkdhf3u74bcxlzvmi2ywirr2sjtrzh7thrbnc3ijz3sq4q": {
+            "bciqgfcifjqcsnr6bkqt6uns6bznczpncptw7cb6qeaafpp4h4tkuk2y": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1633,7 +1633,7 @@
                 {
                   "ty": "posix.envVar",
                   "key": "TG_PORT",
-                  "val": "7891"
+                  "val": "7890"
                 },
                 {
                   "ty": "ghjk.ports.InstallSetRef",
@@ -1641,12 +1641,12 @@
                 }
               ]
             },
-            "bciqgjkrsledgw64yjp4hkj2lpf26pnamtuhsyho7bd55742yprtyv4y": {
+            "bciqgfe63ayh7e7kzg4f47bmaleew7jcdukchs3cg45tvdiwoxotxzfy": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1744,12 +1744,12 @@
                 }
               ]
             },
-            "bciqns7jnxsdugrzboolqtwsh4ohiq5u3p46dezn7huqgo5rq4ps2gja": {
+            "bciqlb6jtozvezqdgkfkfxlztreqi2j6lxqdk5zvvlbc2o5ka7qtljji": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1777,12 +1777,12 @@
                 }
               ]
             },
-            "bciqgqffklh7r5setenk7bkrqoyingrbbjbrcj4jka3rttr56ybxruqi": {
+            "bciqkazb54zk6wdbxpizobukdsz5ruxrtlkf6bfwvctdiwzq6lz7unsq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1815,12 +1815,12 @@
                 }
               ]
             },
-            "bciqmqhamsvcr6i7ol37s5kizxnoawcecho4kzqiwxgodztarzdapawa": {
+            "bciqly23hzeass3kah6rgds4wyqenzsrcmtru7nsvht7t23dsjvgynyi": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1853,12 +1853,12 @@
                 }
               ]
             },
-            "bciqp4x2tqplttorqy7ixw4rltvd7i5dknke6f3ba3uzbgymrp3s7aya": {
+            "bciqasv6wmp2sicgg5dbbjxiv5ojm3t3ga3e75y5igacjq4zureobu6q": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1891,12 +1891,12 @@
                 }
               ]
             },
-            "bciqont2hfpi4wf7ul7acfxfdzwt4q4xm4sqpt2x6rvfc3kxxrtguj6i": {
+            "bciqeby2w3rophwmqawnkmicgymgudbcdqjirrz3r7oltu44uqp4emsq": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1924,12 +1924,12 @@
                 }
               ]
             },
-            "bciqniih3pp536jhouqduhilkpdas6uoesz6b2ckvstng6t7rlxz7jjq": {
+            "bciqbjavwy7rbire3zwlpgo2ifwzgnm6ywxqswnh6qxezwuvc4bqhrca": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1957,12 +1957,12 @@
                 }
               ]
             },
-            "bciqcsmfpk6r2kxk4hruhogwj2ddpjmaoftdxu2vtjsfjyawvvb5t5ga": {
+            "bciqkxr25pjywutrwjgdbuqvhukulifkffcybdcswmbdp6g57uyxalty": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -1995,12 +1995,12 @@
                 }
               ]
             },
-            "bciqajdl35eujx4j3ufkysnsqzaisaqtu247kaydoi2x7tvsqig6bzmq": {
+            "bciqmkulmynzdor24gykcjc2vtu2vmzcgavyyytftuf4sibd7yutzmvy": {
               "provides": [
                 {
                   "ty": "posix.envVar",
                   "key": "RUST_LOG",
-                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off"
+                  "val": "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off"
                 },
                 {
                   "ty": "posix.envVar",
@@ -2031,14 +2031,14 @@
           },
           "defaultEnv": "dev",
           "envsNamed": {
-            "main": "bciqiaaqxx3azvrkvlj2eknjj6awsczu4gdcohccrvjpwk3vmkrnyfpi",
-            "_wasm": "bciqdpiup27tflfkq26oirbutkz53wrp34entiq423upf47za7zoq4za",
-            "_python": "bciqea2qrlw3rmfp2edgo2o7utf5ahjpa4r6y4nrw2pbmqm2g2rabviy",
-            "_ecma": "bciqcm5whsy4tzjafjheomwtxzjxz2avqxwgb6ss5kav6fxmmy3lu4ma",
-            "_rust": "bciqp6dugoxl3avklj2uwl77sfbiixbo2vzduaohoeusqjktc63dshzy",
-            "ci": "bciqniih3pp536jhouqduhilkpdas6uoesz6b2ckvstng6t7rlxz7jjq",
-            "dev": "bciqcsmfpk6r2kxk4hruhogwj2ddpjmaoftdxu2vtjsfjyawvvb5t5ga",
-            "oci": "bciqajdl35eujx4j3ufkysnsqzaisaqtu247kaydoi2x7tvsqig6bzmq"
+            "main": "bciqacae7toziicv72e7ugl6kuv25bbxl5ygu5dugtczoojzqkwayp6q",
+            "_wasm": "bciqa4zotbgmulpg3cutg6nu3ptq5merbt2gbf5a26twwcfe7djxchsi",
+            "_python": "bciqovedn2du5h56q6t4nolxi47yddf76bgaobbexfcxsjyuzj465tri",
+            "_ecma": "bciqcqqs4e5l7nqt57e4bku3gjdxs2iruhfdl2ocayrkkcs4otx7ig7a",
+            "_rust": "bciqof7ogmp2lx2bzmkbrtmdmrmj7seytb6bl2sb4uhnsxkf5v24m75i",
+            "ci": "bciqbjavwy7rbire3zwlpgo2ifwzgnm6ywxqswnh6qxezwuvc4bqhrca",
+            "dev": "bciqkxr25pjywutrwjgdbuqvhukulifkffcybdcswmbdp6g57uyxalty",
+            "oci": "bciqmkulmynzdor24gykcjc2vtu2vmzcgavyyytftuf4sibd7yutzmvy"
           }
         }
       }

--- a/ghjk.ts
+++ b/ghjk.ts
@@ -5,6 +5,9 @@ import { file, ports, sedLock, semver, stdDeps } from "./tools/deps.ts";
 import installs from "./tools/installs.ts";
 import tasks from "./tools/tasks/mod.ts";
 
+//
+//
+
 const ghjk = file({
   defaultEnv: Deno.env.get("CI") ? "ci" : Deno.env.get("OCI") ? "oci" : "dev",
   tasks,
@@ -16,7 +19,7 @@ env("main")
   .install(installs.deno)
   .vars({
     RUST_LOG:
-      "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off",
+      "info,typegate=debug,deno=warn,swc_ecma_codegen=off,tracing::span=off,quaint=off",
     TYPEGRAPH_VERSION: "0.0.3",
     CLICOLOR_FORCE: "1",
     CROSS_CONFIG: "tools/Cross.toml",

--- a/ghjk.ts
+++ b/ghjk.ts
@@ -5,9 +5,6 @@ import { file, ports, sedLock, semver, stdDeps } from "./tools/deps.ts";
 import installs from "./tools/installs.ts";
 import tasks from "./tools/tasks/mod.ts";
 
-//
-//
-
 const ghjk = file({
   defaultEnv: Deno.env.get("CI") ? "ci" : Deno.env.get("OCI") ? "oci" : "dev",
   tasks,

--- a/src/metagen/src/client_ts/static/mod.ts
+++ b/src/metagen/src/client_ts/static/mod.ts
@@ -350,7 +350,7 @@ function convertQueryNodeGql(
     : `${node.instanceName}: ${node.nodeName}`;
 
   const args = node.args;
-  if (args) {
+  if (args && Object.keys(args).length > 0) {
     out = `${out} (${
       Object.entries(args)
         .map(([key, val]) => {

--- a/src/typegate/src/log.ts
+++ b/src/typegate/src/log.ts
@@ -15,7 +15,7 @@ if (!sharedConfig.rust_log) {
       break;
     case "DEBUG":
       set(
-        "info,native=trace,sql_schema_connector=warn,tracing=warn,schema_core=warn",
+        "info,native=trace,sql_schema_connector=warn,tracing=warn,schema_core=warn,quaint=warn",
       );
       break;
     case "WARNING":
@@ -27,7 +27,7 @@ if (!sharedConfig.rust_log) {
       break;
     case "INFO":
     default:
-      set("info");
+      set("info,quaint=warn");
       break;
   }
 }

--- a/src/typegate/standalone/src/logger.rs
+++ b/src/typegate/standalone/src/logger.rs
@@ -18,7 +18,10 @@ fn optional_module_path(path: &str) -> String {
 
 pub fn init() {
     if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info,swc_ecma_codegen=off,tracing::span=off");
+        std::env::set_var(
+            "RUST_LOG",
+            "info,swc_ecma_codegen=off,tracing::span=off,quaint=off",
+        );
     }
     let mut builder = env_logger::Builder::from_default_env();
     builder

--- a/src/typegraph/core/src/runtimes/mod.rs
+++ b/src/typegraph/core/src/runtimes/mod.rs
@@ -457,10 +457,6 @@ impl crate::wit::runtimes::Guest for crate::Lib {
         prisma_op!(runtime, model, Aggregate, "aggregate")
     }
 
-    fn prisma_count(runtime: RuntimeId, model: CoreTypeId) -> Result<FuncParams, wit::Error> {
-        prisma_op!(runtime, model, Count, "count")
-    }
-
     fn prisma_group_by(runtime: RuntimeId, model: CoreTypeId) -> Result<FuncParams, wit::Error> {
         prisma_op!(runtime, model, GroupBy, "groupBy")
     }

--- a/src/typegraph/core/wit/typegraph.wit
+++ b/src/typegraph/core/wit/typegraph.wit
@@ -409,7 +409,6 @@ interface runtimes {
     prisma-find-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
     prisma-find-first: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
     prisma-aggregate: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
-    prisma-count: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
     prisma-group-by: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
     prisma-create-one: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;
     prisma-create-many: func(runtime: runtime-id, model: type-id) -> result<func-params, error>;

--- a/src/typegraph/deno/src/providers/prisma.ts
+++ b/src/typegraph/deno/src/providers/prisma.ts
@@ -63,15 +63,6 @@ export class PrismaRuntime extends Runtime {
     return t.Func.fromTypeFunc(type);
   }
 
-  /** create a function for a prisma `count` query */
-  count(model: string | Typedef): t.Func {
-    if (typeof model == "string") {
-      model = genRef(model);
-    }
-    const type = runtimes.prismaCount(this._id, model._id);
-    return t.Func.fromTypeFunc(type);
-  }
-
   /** create a function for a prisma `groupBy` query */
   groupBy(model: string | Typedef): t.Func {
     if (typeof model == "string") {

--- a/src/typegraph/deno/src/typegraph.ts
+++ b/src/typegraph/deno/src/typegraph.ts
@@ -223,7 +223,7 @@ export async function typegraph(
     if (err.payload && !err.cause) {
       err.cause = err.payload;
     }
-    if ("stack" in err.cause) {
+    if (("cause" in err) && ("stack" in err.cause)) {
       console.error(`Error in typegraph '${name}':`);
       for (const msg of err.cause.stack) {
         console.error(`- ${msg}`);
@@ -267,7 +267,7 @@ export async function typegraph(
         log.debug("exiting");
         process.exit(0);
       }
-    }, 10);
+    }, 100);
   }
 
   --counter;

--- a/src/typegraph/python/typegraph/providers/prisma.py
+++ b/src/typegraph/python/typegraph/providers/prisma.py
@@ -62,14 +62,6 @@ class PrismaRuntime(Runtime):
             raise ErrorStack(type.value)
         return t.func.from_type_func(type.value)
 
-    def count(self, model: Union[str, t.typedef]) -> t.func:
-        if isinstance(model, str):
-            model = gen_ref(model)
-        type = runtimes.prisma_count(store, self.id, model._id)
-        if isinstance(type, Err):
-            raise ErrorStack(type.value)
-        return t.func.from_type_func(type.value)
-
     def group_by(self, model: Union[str, t.typedef]) -> t.func:
         if isinstance(model, str):
             model = gen_ref(model)


### PR DESCRIPTION
<!--
Pull requests are squashed and merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog.
-->

<!-- 1. Explain WHAT the change is about -->

- Remove prisma count operation: it does not work, making it work like on the prisma client would complicate the prisma runtime (until we have output transformations...); Use aggregate instead.
- Increase the delay before exiting the process on the nodejs typegraph client to give the CLI time to process all the output.
- Remove `quaint` logs on the typegate (too verbose).

<!-- 2. Explain WHY the change cannot be made simpler -->


<!-- 3. Explain HOW users should update their code -->

#### Migration notes

---

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
