### PR TITLE
fix: `selectAll` infinite recursion

### DIFF
--- a/examples/templates/deno/api/example.ts
+++ b/examples/templates/deno/api/example.ts
@@ -1,4 +1,4 @@
-import { Policy, t, typegraph } from "jsr:@typegraph/sdk@0.5.0-rc.7";
+import { Policy, t, typegraph } from "jsr:@typegraph/sdk@0.5.0-rc.9";
 import { PythonRuntime } from "jsr:@typegraph/sdk@0.5.0-rc.9/runtimes/python";
 import { DenoRuntime } from "jsr:@typegraph/sdk@0.5.0-rc.9/runtimes/deno";
 

--- a/src/metagen-client-rs/src/selection.rs
+++ b/src/metagen-client-rs/src/selection.rs
@@ -393,8 +393,7 @@ where
     SelT: Selection + Into<CompositeSelection>,
 {
     fn all() -> Self {
-        let sel = SelT::all();
-        Self::Get(sel.into(), PhantomData)
+        Self::Skip
     }
 }
 impl<ArgT, SelT, ATy> Selection for CompositeSelectArgs<ArgT, SelT, ATy>

--- a/src/metagen/src/client_ts/static/mod.ts
+++ b/src/metagen/src/client_ts/static/mod.ts
@@ -107,6 +107,12 @@ function _selectionToNodeSet(
               "unreachable: union/either NodeMetas can't have subnodes",
             );
           }
+
+          // skip non explicit composite selection when using selectAll
+          if (subSelections?._ === "selectAll" && !instanceSelection) {
+            continue;
+          }
+
           node.subNodes = _selectionToNodeSet(
             // assume it's a Selection. If it's an argument
             // object, mismatch between the node desc should hopefully

--- a/tests/injection/random_injection_test.ts
+++ b/tests/injection/random_injection_test.ts
@@ -17,62 +17,65 @@ const cases = [
 ];
 
 for (const testCase of cases) {
-  Meta.test({
-    name: testCase.testName,
-    only: false,
-  }, async (t) => {
-    const engine = await t.engine(testCase.typegraph);
+  Meta.test(
+    {
+      name: testCase.testName,
+      only: false,
+    },
+    async (t) => {
+      const engine = await t.engine(testCase.typegraph);
 
-    await t.should("generate random values", async () => {
-      await gql`
-        query {
-          randomUser {
-            id
-            ean
-            name
-            age
-            married
-            birthday
-            phone
-            gender
-            firstname
-            lastname
-            friends
-            occupation
-            street
-            city
-            postcode
-            country
-            uri
-            hostname
+      await t.should("generate random values", async () => {
+        await gql`
+          query {
+            randomUser {
+              id
+              ean
+              name
+              age
+              married
+              birthday
+              phone
+              gender
+              firstname
+              lastname
+              friends
+              occupation
+              street
+              city
+              postcode
+              country
+              uri
+              hostname
+            }
           }
-        }
-      `
-        .expectData({
-          randomUser: {
-            id: "1069ace0-cdb1-5c1f-8193-81f53d29da35",
-            ean: "0497901391205",
-            name: "Landon Glover",
-            age: 38,
-            married: true,
-            birthday: "2124-06-22T22:00:07.302Z",
-            phone: "(587) 901-3720",
-            gender: "Male",
-            firstname: "Landon",
-            lastname: "Mengoni",
-            friends: ["Hettie", "Mary", "Lydia", "Ethel", "Jennie"],
-            occupation: "Health Care Manager",
-            street: "837 Wubju Drive",
-            city: "Urbahfec",
-            postcode: "IM9 9AD",
-            country: "Indonesia",
-            uri: "http://wubju.bs/ma",
-            hostname: "wubju.bs",
-          },
-        })
-        .on(engine);
-    });
-  });
+        `
+          .expectData({
+            randomUser: {
+              id: "1069ace0-cdb1-5c1f-8193-81f53d29da35",
+              ean: "0497901391205",
+              name: "Landon Glover",
+              age: 38,
+              married: true,
+              birthday: "2125-06-22T22:00:07.302Z",
+              phone: "(587) 901-3720",
+              gender: "Male",
+              firstname: "Landon",
+              lastname: "Mengoni",
+              friends: ["Hettie", "Mary", "Lydia", "Ethel", "Jennie"],
+              occupation: "Health Care Manager",
+              street: "837 Wubju Drive",
+              city: "Urbahfec",
+              postcode: "IM9 9AD",
+              country: "Indonesia",
+              uri: "http://wubju.bs/ma",
+              hostname: "wubju.bs",
+            },
+          })
+          .on(engine);
+      });
+    },
+  );
 }
 
 Meta.test("random injection on unions", async (t) => {
@@ -80,88 +83,92 @@ Meta.test("random injection on unions", async (t) => {
 
   await t.should("work on random lists", async () => {
     await gql`
-            query {
-                randomList {
-                    names
-                }
-            }
-        `.expectData({
-      randomList: {
-        names: [
-          "Hettie Huff",
-          "Ada Mills",
-          "Ethel Marshall",
-          "Emily Gonzales",
-          "Lottie Barber",
-        ],
-      },
-    }).on(engine);
+      query {
+        randomList {
+          names
+        }
+      }
+    `
+      .expectData({
+        randomList: {
+          names: [
+            "Hettie Huff",
+            "Ada Mills",
+            "Ethel Marshall",
+            "Emily Gonzales",
+            "Lottie Barber",
+          ],
+        },
+      })
+      .on(engine);
   });
 
   await t.should(
     "generate random values for enums, either and union variants",
     async () => {
       await gql`
-      query {
-        testEnumStr {
-          educationLevel
-        },
-        testEnumInt {
-          bits
-        },
-        testEnumFloat {
-          cents
-        },
-        testEither {
-          toy {
-            ... on Toygun {
-              color
-            }
-            ... on Rubix {
-              name,
-              size
+        query {
+          testEnumStr {
+            educationLevel
+          }
+          testEnumInt {
+            bits
+          }
+          testEnumFloat {
+            cents
+          }
+          testEither {
+            toy {
+              ... on Toygun {
+                color
+              }
+              ... on Rubix {
+                name
+                size
+              }
             }
           }
-        },
-        testUnion {
-          field {
-            ... on Rgb {
-              R
-              G
-              B
-            }
-            ... on Vec {
-              x
-              y
-              z
+          testUnion {
+            field {
+              ... on Rgb {
+                R
+                G
+                B
+              }
+              ... on Vec {
+                x
+                y
+                z
+              }
             }
           }
         }
-      }
-    `.expectData({
-        testEnumStr: {
-          educationLevel: "secondary",
-        },
-        testEnumInt: {
-          bits: 0,
-        },
-        testEnumFloat: {
-          cents: 0.5,
-        },
-        testEither: {
-          toy: {
-            name: "1*ajw]krgDnCzXD*N!Fx",
-            size: 3336617896968192,
+      `
+        .expectData({
+          testEnumStr: {
+            educationLevel: "secondary",
           },
-        },
-        testUnion: {
-          field: {
-            B: 779226068287.488,
-            G: 396901315143.2704,
-            R: 895648526657.1263,
+          testEnumInt: {
+            bits: 0,
           },
-        },
-      }).on(engine);
+          testEnumFloat: {
+            cents: 0.5,
+          },
+          testEither: {
+            toy: {
+              name: "1*ajw]krgDnCzXD*N!Fx",
+              size: 3336617896968192,
+            },
+          },
+          testUnion: {
+            field: {
+              B: 779226068287.488,
+              G: 396901315143.2704,
+              R: 895648526657.1263,
+            },
+          },
+        })
+        .on(engine);
     },
   );
 });

--- a/tests/metagen/metagen_test.ts
+++ b/tests/metagen/metagen_test.ts
@@ -592,6 +592,24 @@ Meta.test(
       compositeNoArgs: postSchema,
       compositeArgs: postSchema,
     });
+    const expectedSchemaC = zod.object({
+      scalarOnly: zod.object({ scalar: zod.number() }),
+      withStruct: zod.object({
+        scalar: zod.number(),
+        composite: zod.object({ value: zod.number() }),
+      }),
+      withStructNested: zod.object({
+        scalar: zod.number(),
+        composite: zod.object({
+          value: zod.number(),
+          nested: zod.object({ inner: zod.number() }),
+        }),
+      }),
+      withList: zod.object({
+        scalar: zod.number(),
+        list: zod.array(zod.object({ value: zod.number() })),
+      }),
+    });
     const expectedSchema = zod.tuple([
       expectedSchemaQ,
       expectedSchemaQ,
@@ -604,6 +622,7 @@ Meta.test(
         compositeUnion2: zod.object({}),
         mixedUnion: zod.string(),
       }),
+      expectedSchemaC,
     ]);
     const cases = [
       {

--- a/tests/metagen/typegraphs/identities/rs/fdk.rs
+++ b/tests/metagen/typegraphs/identities/rs/fdk.rs
@@ -109,7 +109,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.5.0-rc.8";
+        static MT_VERSION: &str = "0.5.0-rc.9";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }

--- a/tests/metagen/typegraphs/sample/py/main.py
+++ b/tests/metagen/typegraphs/sample/py/main.py
@@ -141,4 +141,31 @@ res5 = gql_client.query(
     }
 )
 
-print(json.dumps([res1, res1a, res2, res3, res4, res5]))
+res6 = gql_client.query(
+    {
+        "scalarOnly": qg.nested_composite({"_": SelectionFlags(select_all=True)}),
+        "withStruct": qg.nested_composite(
+            {
+                "_": SelectionFlags(select_all=True),
+                "composite": {"_": SelectionFlags(select_all=True)},
+            }
+        ),
+        "withStructNested": qg.nested_composite(
+            {
+                "_": SelectionFlags(select_all=True),
+                "composite": {
+                    "_": SelectionFlags(select_all=True),
+                    "nested": {"_": SelectionFlags(select_all=True)},
+                },
+            }
+        ),
+        "withList": qg.nested_composite(
+            {
+                "_": SelectionFlags(select_all=True),
+                "list": {"_": SelectionFlags(select_all=True)},
+            }
+        ),
+    },
+)
+
+print(json.dumps([res1, res1a, res2, res3, res4, res5, res6]))

--- a/tests/metagen/typegraphs/sample/py_upload/client.py
+++ b/tests/metagen/typegraphs/sample/py_upload/client.py
@@ -20,12 +20,12 @@ def selection_to_nodes(
     parent_path: str,
 ) -> typing.List["SelectNode[typing.Any]"]:
     out = []
-    flags = selection.get("_")
-    if flags is not None and not isinstance(flags, SelectionFlags):
+    sub_flags = selection.get("_")
+    if sub_flags is not None and not isinstance(sub_flags, SelectionFlags):
         raise Exception(
-            f"selection field '_' should be of type SelectionFlags but found {type(flags)}"
+            f"selection field '_' should be of type SelectionFlags but found {type(sub_flags)}"
         )
-    select_all = True if flags is not None and flags.select_all else False
+    select_all = True if sub_flags is not None and sub_flags.select_all else False
     found_nodes = set(selection.keys())
     for node_name, meta_fn in metas.items():
         found_nodes.discard(node_name)
@@ -107,7 +107,7 @@ def selection_to_nodes(
 
                 # flags are recursive for any subnode that's not specified
                 if sub_selections is None:
-                    sub_selections = {"_": flags}
+                    sub_selections = {"_": sub_flags}
 
                 # selection types are always TypedDicts as well
                 if not isinstance(sub_selections, dict):
@@ -122,6 +122,17 @@ def selection_to_nodes(
                         raise Exception(
                             "unreachable: union/either NodeMetas can't have subnodes"
                         )
+
+                    # skip non explicit composite selection when using select_all
+                    sub_flags = sub_selections.get("_")
+
+                    if (
+                        isinstance(sub_flags, SelectionFlags)
+                        and sub_flags.select_all
+                        and instance_selection is None
+                    ):
+                        continue
+
                     sub_nodes = selection_to_nodes(
                         typing.cast("SelectionErased", sub_selections),
                         meta.sub_nodes,

--- a/tests/metagen/typegraphs/sample/rs/client.rs
+++ b/tests/metagen/typegraphs/sample/rs/client.rs
@@ -164,6 +164,62 @@ mod node_metas {
             ..RootMixedUnionFnOutput()
         }
     }
+    pub fn RootNestedCompositeFnOutputCompositeStructNestedStruct() -> NodeMeta {
+        NodeMeta {
+            arg_types: None,
+            variants: None,
+            sub_nodes: Some(
+                [
+                    ("inner".into(), scalar as NodeMetaFn),
+                ].into()
+            ),
+            input_files: None,
+        }
+    }
+    pub fn RootNestedCompositeFnOutputCompositeStruct() -> NodeMeta {
+        NodeMeta {
+            arg_types: None,
+            variants: None,
+            sub_nodes: Some(
+                [
+                    ("value".into(), scalar as NodeMetaFn),
+                    ("nested".into(), RootNestedCompositeFnOutputCompositeStructNestedStruct as NodeMetaFn),
+                ].into()
+            ),
+            input_files: None,
+        }
+    }
+    pub fn RootNestedCompositeFnOutputListStruct() -> NodeMeta {
+        NodeMeta {
+            arg_types: None,
+            variants: None,
+            sub_nodes: Some(
+                [
+                    ("value".into(), scalar as NodeMetaFn),
+                ].into()
+            ),
+            input_files: None,
+        }
+    }
+    pub fn RootNestedCompositeFnOutput() -> NodeMeta {
+        NodeMeta {
+            arg_types: None,
+            variants: None,
+            sub_nodes: Some(
+                [
+                    ("scalar".into(), scalar as NodeMetaFn),
+                    ("composite".into(), RootNestedCompositeFnOutputCompositeStruct as NodeMetaFn),
+                    ("list".into(), RootNestedCompositeFnOutputListStruct as NodeMetaFn),
+                ].into()
+            ),
+            input_files: None,
+        }
+    }
+    pub fn RootNestedCompositeFn() -> NodeMeta {
+        NodeMeta {
+            ..RootNestedCompositeFnOutput()
+        }
+    }
 
 }
 use types::*;
@@ -209,6 +265,26 @@ pub mod types {
         PostSlugString(PostSlugString),
         RootScalarUnionFnOutputT1Integer(RootScalarUnionFnOutputT1Integer),
     }
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    pub struct RootNestedCompositeFnOutputCompositeStructNestedStructPartial {
+        pub inner: Option<RootScalarUnionFnOutputT1Integer>,
+    }
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    pub struct RootNestedCompositeFnOutputCompositeStructPartial {
+        pub value: Option<RootScalarUnionFnOutputT1Integer>,
+        pub nested: Option<RootNestedCompositeFnOutputCompositeStructNestedStructPartial>,
+    }
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    pub struct RootNestedCompositeFnOutputListStructPartial {
+        pub value: Option<RootScalarUnionFnOutputT1Integer>,
+    }
+    pub type RootNestedCompositeFnOutputListRootNestedCompositeFnOutputListStructList = Vec<RootNestedCompositeFnOutputListStructPartial>;
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    pub struct RootNestedCompositeFnOutputPartial {
+        pub scalar: Option<RootScalarUnionFnOutputT1Integer>,
+        pub composite: Option<RootNestedCompositeFnOutputCompositeStructPartial>,
+        pub list: Option<RootNestedCompositeFnOutputListRootNestedCompositeFnOutputListStructList>,
+    }
 }
 #[derive(Default, Debug)]
 pub struct PostSelections<ATy = NoAlias> {
@@ -236,6 +312,29 @@ pub struct RootMixedUnionFnOutputSelections<ATy = NoAlias> {
     pub user: CompositeSelect<UserSelections<ATy>, NoAlias>,
 }
 impl_union_selection_traits!(RootMixedUnionFnOutputSelections, ("post", post), ("user", user));
+#[derive(Default, Debug)]
+pub struct RootNestedCompositeFnOutputCompositeStructNestedStructSelections<ATy = NoAlias> {
+    pub inner: ScalarSelect<ATy>,
+}
+impl_selection_traits!(RootNestedCompositeFnOutputCompositeStructNestedStructSelections, inner);
+#[derive(Default, Debug)]
+pub struct RootNestedCompositeFnOutputCompositeStructSelections<ATy = NoAlias> {
+    pub value: ScalarSelect<ATy>,
+    pub nested: CompositeSelect<RootNestedCompositeFnOutputCompositeStructNestedStructSelections<ATy>, ATy>,
+}
+impl_selection_traits!(RootNestedCompositeFnOutputCompositeStructSelections, value, nested);
+#[derive(Default, Debug)]
+pub struct RootNestedCompositeFnOutputListStructSelections<ATy = NoAlias> {
+    pub value: ScalarSelect<ATy>,
+}
+impl_selection_traits!(RootNestedCompositeFnOutputListStructSelections, value);
+#[derive(Default, Debug)]
+pub struct RootNestedCompositeFnOutputSelections<ATy = NoAlias> {
+    pub scalar: ScalarSelect<ATy>,
+    pub composite: CompositeSelect<RootNestedCompositeFnOutputCompositeStructSelections<ATy>, ATy>,
+    pub list: CompositeSelect<RootNestedCompositeFnOutputListStructSelections<ATy>, ATy>,
+}
+impl_selection_traits!(RootNestedCompositeFnOutputSelections, scalar, composite, list);
 
 impl QueryGraph {
 
@@ -380,6 +479,17 @@ impl QueryGraph {
             root_name: "mixedUnion".into(),
             root_meta: node_metas::RootMixedUnionFn,
             args: args.into().into(),
+            _marker: PhantomData,
+        }
+    }
+    pub fn nested_composite(
+        &self,
+    ) -> UnselectedNode<RootNestedCompositeFnOutputSelections, RootNestedCompositeFnOutputSelections<HasAlias>, QueryMarker, RootNestedCompositeFnOutputPartial>
+    {
+        UnselectedNode {
+            root_name: "nestedComposite".into(),
+            root_meta: node_metas::RootNestedCompositeFn,
+            args: NodeArgsErased::None,
             _marker: PhantomData,
         }
     }

--- a/tests/metagen/typegraphs/sample/rs/main.rs
+++ b/tests/metagen/typegraphs/sample/rs/main.rs
@@ -136,6 +136,35 @@ fn main() -> Result<(), BoxErr> {
                     }),
                 ))
                 .await?;
+
+            let res6 = gql
+                .query((
+                    api1.nested_composite().select(all()),
+                    api1.nested_composite()
+                        .select(RootNestedCompositeFnOutputSelections {
+                            composite: select(all()),
+                            ..all()
+                        }),
+                    api1.nested_composite()
+                        .select(RootNestedCompositeFnOutputSelections {
+                        composite: select(RootNestedCompositeFnOutputCompositeStructSelections {
+                            nested: select(
+                                RootNestedCompositeFnOutputCompositeStructNestedStructSelections {
+                                    ..all()
+                                },
+                            ),
+                            ..all()
+                        }),
+                        ..all()
+                    }),
+                    api1.nested_composite()
+                        .select(RootNestedCompositeFnOutputSelections {
+                            list: select(all()),
+                            ..all()
+                        }),
+                ))
+                .await?;
+
             println!(
                 "{}",
                 serde_json::to_string_pretty(&serde_json::json!([
@@ -169,6 +198,12 @@ fn main() -> Result<(), BoxErr> {
                         "compositeUnion1": res5.1,
                         "compositeUnion2": res5.2,
                         "mixedUnion": res5.3
+                    },
+                    {
+                        "scalarOnly": res6.0,
+                        "withStruct": res6.1,
+                        "withStructNested": res6.2,
+                        "withList": res6.3
                     }
                 ]))?
             );

--- a/tests/metagen/typegraphs/sample/ts/client.ts
+++ b/tests/metagen/typegraphs/sample/ts/client.ts
@@ -110,6 +110,12 @@ function _selectionToNodeSet(
               "unreachable: union/either NodeMetas can't have subnodes",
             );
           }
+
+          // skip non explicit composite selection when using selectAll
+          if (subSelections?._ === "selectAll" && !instanceSelection) {
+            continue;
+          }
+
           node.subNodes = _selectionToNodeSet(
             // assume it's a Selection. If it's an argument
             // object, mismatch between the node desc should hopefully
@@ -968,6 +974,42 @@ const nodeMetas = {
       },
     };
   },
+  RootNestedCompositeFnOutputCompositeStructNestedStruct(): NodeMeta {
+    return {
+      subNodes: [
+        ["inner", nodeMetas.scalar],
+      ],
+    };
+  },
+  RootNestedCompositeFnOutputCompositeStruct(): NodeMeta {
+    return {
+      subNodes: [
+        ["value", nodeMetas.scalar],
+        ["nested", nodeMetas.RootNestedCompositeFnOutputCompositeStructNestedStruct],
+      ],
+    };
+  },
+  RootNestedCompositeFnOutputListStruct(): NodeMeta {
+    return {
+      subNodes: [
+        ["value", nodeMetas.scalar],
+      ],
+    };
+  },
+  RootNestedCompositeFnOutput(): NodeMeta {
+    return {
+      subNodes: [
+        ["scalar", nodeMetas.scalar],
+        ["composite", nodeMetas.RootNestedCompositeFnOutputCompositeStruct],
+        ["list", nodeMetas.RootNestedCompositeFnOutputListStruct],
+      ],
+    };
+  },
+  RootNestedCompositeFn(): NodeMeta {
+    return {
+      ...nodeMetas.RootNestedCompositeFnOutput(),
+    };
+  },
 };
 export type UserIdStringUuid = string;
 export type PostSlugString = string;
@@ -998,6 +1040,22 @@ export type RootMixedUnionFnOutput =
   | (User)
   | (PostSlugString)
   | (RootScalarUnionFnOutputT1Integer);
+export type RootNestedCompositeFnOutputCompositeStructNestedStruct = {
+  inner: RootScalarUnionFnOutputT1Integer;
+};
+export type RootNestedCompositeFnOutputCompositeStruct = {
+  value: RootScalarUnionFnOutputT1Integer;
+  nested: RootNestedCompositeFnOutputCompositeStructNestedStruct;
+};
+export type RootNestedCompositeFnOutputListStruct = {
+  value: RootScalarUnionFnOutputT1Integer;
+};
+export type RootNestedCompositeFnOutputListRootNestedCompositeFnOutputListStructList = Array<RootNestedCompositeFnOutputListStruct>;
+export type RootNestedCompositeFnOutput = {
+  scalar: RootScalarUnionFnOutputT1Integer;
+  composite: RootNestedCompositeFnOutputCompositeStruct;
+  list: RootNestedCompositeFnOutputListRootNestedCompositeFnOutputListStructList;
+};
 
 export type PostSelections = {
   _?: SelectionFlags;
@@ -1020,6 +1078,25 @@ export type RootMixedUnionFnOutputSelections = {
   _?: SelectionFlags;
   "post"?: CompositeSelectNoArgs<PostSelections>;
   "user"?: CompositeSelectNoArgs<UserSelections>;
+};
+export type RootNestedCompositeFnOutputCompositeStructNestedStructSelections = {
+  _?: SelectionFlags;
+  inner?: ScalarSelectNoArgs;
+};
+export type RootNestedCompositeFnOutputCompositeStructSelections = {
+  _?: SelectionFlags;
+  value?: ScalarSelectNoArgs;
+  nested?: CompositeSelectNoArgs<RootNestedCompositeFnOutputCompositeStructNestedStructSelections>;
+};
+export type RootNestedCompositeFnOutputListStructSelections = {
+  _?: SelectionFlags;
+  value?: ScalarSelectNoArgs;
+};
+export type RootNestedCompositeFnOutputSelections = {
+  _?: SelectionFlags;
+  scalar?: ScalarSelectNoArgs;
+  composite?: CompositeSelectNoArgs<RootNestedCompositeFnOutputCompositeStructSelections>;
+  list?: CompositeSelectNoArgs<RootNestedCompositeFnOutputListStructSelections>;
 };
 
 export class QueryGraph extends _QueryGraphBase {
@@ -1103,5 +1180,13 @@ export class QueryGraph extends _QueryGraphBase {
       "$q",
     )[0];
     return new QueryNode(inner) as QueryNode<RootMixedUnionFnOutput>;
+  }
+  nestedComposite(select: RootNestedCompositeFnOutputSelections) {
+    const inner = _selectionToNodeSet(
+      { "nestedComposite": select },
+      [["nestedComposite", nodeMetas.RootNestedCompositeFn]],
+      "$q",
+    )[0];
+    return new QueryNode(inner) as QueryNode<RootNestedCompositeFnOutput>;
   }
 }

--- a/tests/metagen/typegraphs/sample/ts/main.ts
+++ b/tests/metagen/typegraphs/sample/ts/main.ts
@@ -22,27 +22,32 @@ const preparedQ = gqlClient.prepareQuery(() => ({
   scalarNoArgs: api1.scalarNoArgs(),
 }));
 
-const preparedM = gqlClient.prepareMutation((
-  args: PreparedArgs<{
-    id: string;
-    slug: string;
-    title: string;
-  }>,
-) => ({
-  scalarArgs: api1.scalarArgs({
-    id: args.get("id"),
-    slug: args.get("slug"),
-    title: args.get("title"),
+const preparedM = gqlClient.prepareMutation(
+  (
+    args: PreparedArgs<{
+      id: string;
+      slug: string;
+      title: string;
+    }>,
+  ) => ({
+    scalarArgs: api1.scalarArgs({
+      id: args.get("id"),
+      slug: args.get("slug"),
+      title: args.get("title"),
+    }),
+    compositeNoArgs: api1.compositeNoArgs({
+      _: "selectAll",
+    }),
+    compositeArgs: api1.compositeArgs(
+      {
+        id: args.get("id"),
+      },
+      {
+        _: "selectAll",
+      },
+    ),
   }),
-  compositeNoArgs: api1.compositeNoArgs({
-    _: "selectAll",
-  }),
-  compositeArgs: api1.compositeArgs({
-    id: args.get("id"),
-  }, {
-    _: "selectAll",
-  }),
-}));
+);
 
 const res1 = await preparedQ.perform({});
 const res1a = await preparedQ.perform({});
@@ -75,41 +80,71 @@ const res4 = await gqlClient.mutation({
   compositeNoArgs: api1.compositeNoArgs({
     _: "selectAll",
   }),
-  compositeArgs: api1.compositeArgs({
-    id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
-  }, {
-    _: "selectAll",
-  }),
+  compositeArgs: api1.compositeArgs(
+    {
+      id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
+    },
+    {
+      _: "selectAll",
+    },
+  ),
 });
 
 const res5 = await gqlClient.query({
   scalarUnion: api1.scalarUnion({
     id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
   }),
-  compositeUnion1: api1.compositeUnion({
-    id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
-  }, {
-    post: {
-      "_": "selectAll",
+  compositeUnion1: api1.compositeUnion(
+    {
+      id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
     },
+    {
+      post: {
+        _: "selectAll",
+      },
+    },
+  ),
+  compositeUnion2: api1.compositeUnion(
+    {
+      id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
+    },
+    {
+      user: {
+        _: "selectAll",
+        posts: { _: "selectAll" },
+      },
+    },
+  ),
+  mixedUnion: api1.mixedUnion(
+    {
+      id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
+    },
+    {
+      post: {
+        _: "selectAll",
+      },
+      user: {
+        _: "selectAll",
+        posts: { _: "selectAll" },
+      },
+    },
+  ),
+});
+
+const res6 = await gqlClient.query({
+  scalarOnly: api1.nestedComposite({ _: "selectAll" }),
+  withStruct: api1.nestedComposite({
+    _: "selectAll",
+    composite: { _: "selectAll" },
   }),
-  compositeUnion2: api1.compositeUnion({
-    id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
-  }, {
-    user: {
-      "_": "selectAll",
-    },
+  withStructNested: api1.nestedComposite({
+    _: "selectAll",
+    composite: { _: "selectAll", nested: { _: "selectAll" } },
   }),
-  mixedUnion: api1.mixedUnion({
-    id: "94be5420-8c4a-4e67-b4f4-e1b2b54832a2",
-  }, {
-    post: {
-      "_": "selectAll",
-    },
-    user: {
-      "_": "selectAll",
-    },
+  withList: api1.nestedComposite({
+    _: "selectAll",
+    list: { _: "selectAll" },
   }),
 });
 
-console.log(JSON.stringify([res1, res1a, res2, res3, res4, res5]));
+console.log(JSON.stringify([res1, res1a, res2, res3, res4, res5, res6]));

--- a/tests/metagen/typegraphs/sample/ts_upload/client.ts
+++ b/tests/metagen/typegraphs/sample/ts_upload/client.ts
@@ -110,6 +110,12 @@ function _selectionToNodeSet(
               "unreachable: union/either NodeMetas can't have subnodes",
             );
           }
+
+          // skip non explicit composite selection when using selectAll
+          if (subSelections?._ === "selectAll" && !instanceSelection) {
+            continue;
+          }
+
           node.subNodes = _selectionToNodeSet(
             // assume it's a Selection. If it's an argument
             // object, mismatch between the node desc should hopefully


### PR DESCRIPTION
<!--
Pull requests are squashed and merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog.
-->

<!-- 1. Explain WHAT the change is about -->

- Closes [MET-786](https://linear.app/metatypedev/issue/MET-786/typescript-client-selectall-infinite-recursion).

<!-- 3. Explain HOW users should update their code -->

#### Migration notes

---

- [x] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added nested composite structure support across multiple client implementations
	- Enhanced selection handling for composite queries
	- Expanded type definitions for more complex data representations

- **Bug Fixes**
	- Improved selection processing logic in client implementations
	- Updated version compatibility for SDK imports

- **Chores**
	- Updated package dependencies to newer SDK versions
	- Reformatted and improved code readability across multiple files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->