### PR TITLE
fix(gate,sdk): fail fast on bad credentials before artifact upload

### DIFF
--- a/src/typegate/src/runtimes/typegate.ts
+++ b/src/typegate/src/runtimes/typegate.ts
@@ -114,7 +114,8 @@ export class TypeGateRuntime extends Runtime {
           return this.execRawPrismaQuery;
         case "queryPrismaModel":
           return this.queryPrismaModel;
-
+        case "ping":
+            return (_) => true;
         default:
           if (name != null) {
             throw new Error(`materializer '${name}' not implemented`);

--- a/src/typegate/src/typegraphs/typegate.json
+++ b/src/typegate/src/typegraphs/typegate.json
@@ -15,7 +15,8 @@
         "execRawPrismaCreate": 64,
         "execRawPrismaUpdate": 65,
         "execRawPrismaDelete": 66,
-        "queryPrismaModel": 67
+        "queryPrismaModel": 67,
+        "ping": 71
       },
       "id": [],
       "required": [
@@ -30,7 +31,8 @@
         "execRawPrismaCreate",
         "execRawPrismaUpdate",
         "execRawPrismaDelete",
-        "queryPrismaModel"
+        "queryPrismaModel",
+        "ping"
       ],
       "policies": {
         "typegraphs": [
@@ -67,6 +69,9 @@
           0
         ],
         "queryPrismaModel": [
+          0
+        ],
+        "ping": [
           0
         ]
       }
@@ -794,6 +799,16 @@
         "rowCount": [],
         "data": []
       }
+    },
+    {
+      "type": "function",
+      "title": "root_ping_fn",
+      "input": 2,
+      "output": 25,
+      "runtimeConfig": null,
+      "materializer": 14,
+      "rate_weight": null,
+      "rate_calls": false
     }
   ],
   "materializers": [
@@ -925,6 +940,15 @@
     },
     {
       "name": "queryPrismaModel",
+      "runtime": 1,
+      "effect": {
+        "effect": "read",
+        "idempotent": true
+      },
+      "data": {}
+    },
+    {
+      "name": "ping",
       "runtime": 1,
       "effect": {
         "effect": "read",

--- a/src/typegate/src/typegraphs/typegate.py
+++ b/src/typegate/src/typegraphs/typegate.py
@@ -146,6 +146,11 @@ def typegate(g: Graph):
         raise Exception(arg_info_by_path_id.value)
     arg_info_by_path_mat = Materializer(arg_info_by_path_id.value, effect=fx.read())
 
+    ping_mat_id = runtimes.register_typegate_materializer(store, TypegateOperation.PING)
+    if isinstance(ping_mat_id, Err):
+        raise Exception(ping_mat_id.value)
+    ping_mat = Materializer(ping_mat_id.value, effect=fx.read())
+
     serialized = t.gen(t.string(), serialized_typegraph_mat)
 
     typegraph = t.struct(
@@ -419,4 +424,9 @@ def typegate(g: Graph):
             raw_prisma_delete_mat,
         ),
         queryPrismaModel=query_prisma_model,
+        ping=t.func(
+            t.struct({}),
+            t.boolean(),  # always True
+            ping_mat,
+        ),
     )

--- a/src/typegraph/core/src/runtimes/mod.rs
+++ b/src/typegraph/core/src/runtimes/mod.rs
@@ -654,6 +654,7 @@ impl crate::wit::runtimes::Guest for crate::Lib {
             WitOp::RawPrismaUpdate => (WitEffect::Update(false), Op::RawPrismaQuery),
             WitOp::RawPrismaDelete => (WitEffect::Delete(true), Op::RawPrismaQuery),
             WitOp::QueryPrismaModel => (WitEffect::Read, Op::QueryPrismaModel),
+            WitOp::Ping => (WitEffect::Read, Op::Ping),
         };
 
         Ok(Store::register_materializer(Materializer::typegate(

--- a/src/typegraph/core/src/runtimes/typegate.rs
+++ b/src/typegraph/core/src/runtimes/typegate.rs
@@ -21,6 +21,7 @@ pub enum TypegateOperation {
     FindPrismaModels,
     RawPrismaQuery,
     QueryPrismaModel,
+    Ping,
 }
 
 impl MaterializerConverter for TypegateOperation {
@@ -44,6 +45,7 @@ impl MaterializerConverter for TypegateOperation {
                 Self::FindPrismaModels => "findPrismaModels",
                 Self::RawPrismaQuery => "execRawPrismaQuery",
                 Self::QueryPrismaModel => "queryPrismaModel",
+                Self::Ping => "ping",
             }
             .to_string(),
             runtime,

--- a/src/typegraph/core/src/utils/mod.rs
+++ b/src/typegraph/core/src/utils/mod.rs
@@ -114,8 +114,8 @@ impl crate::wit::utils::Guest for crate::Lib {
             .build(named_provider(&service_name)?)
     }
 
-    fn gql_deploy_query(params: QueryDeployParams) -> Result<String> {
-        let query = r"
+    fn gql_deploy_query(params: QueryDeployParams) -> String {
+        let query = "
             mutation InsertTypegraph($tg: String!, $secrets: String!, $targetVersion: String!) {
                 addTypegraph(fromString: $tg, secrets: $secrets, targetVersion: $targetVersion) {
                     name
@@ -128,8 +128,8 @@ impl crate::wit::utils::Guest for crate::Lib {
 
         let mut secrets_map = IndexMap::new();
         if let Some(secrets) = params.secrets {
-            for item in secrets {
-                secrets_map.insert(item.0, item.1);
+            for (secret, value) in secrets {
+                secrets_map.insert(secret, value);
             }
         }
 
@@ -143,11 +143,11 @@ impl crate::wit::utils::Guest for crate::Lib {
             }),
         });
 
-        Ok(req_body.to_string())
+        req_body.to_string()
     }
 
-    fn gql_remove_query(names: Vec<String>) -> Result<String> {
-        let query = r"
+    fn gql_remove_query(names: Vec<String>) -> String {
+        let query = "
             mutation($names: [String!]!) {
                 removeTypegraphs(names: $names)
             }
@@ -156,9 +156,20 @@ impl crate::wit::utils::Guest for crate::Lib {
             "query": query,
             "variables": json!({
                 "names":  names,
-              }),
+            }),
         });
-        Ok(req_body.to_string())
+
+        req_body.to_string()
+    }
+
+    fn gql_ping_query() -> String {
+        let query = "query { ping }";
+        let req_body = json!({
+            "query": query,
+            "variables": json!({}),
+        });
+
+        req_body.to_string()
     }
 
     fn metagen_exec(config: FdkConfig) -> Result<Vec<FdkOutput>> {

--- a/src/typegraph/core/wit/typegraph.wit
+++ b/src/typegraph/core/wit/typegraph.wit
@@ -472,6 +472,7 @@ interface runtimes {
         raw-prisma-update,
         raw-prisma-delete,
         query-prisma-model,
+        ping,
     }
 
     register-typegate-materializer: func(operation: typegate-operation) -> result<materializer-id, error>;
@@ -638,8 +639,9 @@ interface utils {
         secrets: option<list<tuple<string, string>>>,
     }
 
-    gql-deploy-query: func(params: query-deploy-params) -> result<string, error>;
-    gql-remove-query: func(tg-name: list<string>) -> result<string, error>;
+    gql-deploy-query: func(params: query-deploy-params) -> string;
+    gql-remove-query: func(tg-name: list<string>) -> string;
+    gql-ping-query: func() -> string;
 
     record fdk-config {
         workspace-path: string,

--- a/src/typegraph/deno/src/tg_deploy.ts
+++ b/src/typegraph/deno/src/tg_deploy.ts
@@ -85,6 +85,10 @@ export async function tgDeploy(
   if (typegate.auth) {
     headers.append("Authorization", typegate.auth.asHeaderValue());
   }
+  const url = new URL("/typegate", typegate.url);
+
+  // Make sure we have the correct credentials before doing anything
+  await pingTypegate(url, headers);
 
   if (refArtifacts.length > 0) {
     // upload the artifacts
@@ -103,7 +107,7 @@ export async function tgDeploy(
 
   // deploy the typegraph
   const response = (await execRequest(
-    new URL("/typegate", typegate.url),
+    url,
     {
       method: "POST",
       headers,
@@ -164,4 +168,19 @@ export async function tgRemove(
   )) as Record<string, any> | string;
 
   return { typegate: response };
+}
+
+export async function pingTypegate(
+  url: URL,
+  headers: Headers,
+) {
+  await execRequest(
+      url,
+    {
+      method: "POST",
+      headers,
+      body: wit_utils.gqlPingQuery(),
+    },
+    "Failed to access typegate",
+  );
 }

--- a/tests/e2e/self_deploy/self_deploy_bad_cred_test.ts
+++ b/tests/e2e/self_deploy/self_deploy_bad_cred_test.ts
@@ -1,0 +1,40 @@
+// Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
+// SPDX-License-Identifier: MPL-2.0
+import { BasicAuth, tgDeploy } from "@typegraph/sdk/tg_deploy";
+
+import { Meta } from "test-utils/mod.ts";
+import { tg } from "./self_deploy.ts";
+import { testDir } from "test-utils/dir.ts";
+import { join } from "@std/path/join";
+import { unreachable } from "@std/assert";
+import * as path from "@std/path";
+import { assertStringIncludes } from "@std/assert/string-includes";
+
+Meta.test(
+  {
+    name: "typegate should fail after ping on bad credential",
+  },
+  async (t) => {
+    const gate = `http://localhost:${t.port}`;
+    const auth = new BasicAuth("admin", "wrong password");
+    const cwdDir = join(testDir, "e2e", "self_deploy");
+
+    try {
+      const _ = await tgDeploy(tg, {
+        typegate: { url: gate, auth },
+        secrets: {},
+        typegraphPath: path.join(cwdDir, "self_deploy.ts"),
+        migrationsDir: `${cwdDir}/prisma-migrations`,
+        defaultMigrationAction: {
+          apply: true,
+          create: true,
+          reset: false,
+        },
+      });
+
+      unreachable();
+    } catch(err) {
+      assertStringIncludes(JSON.stringify(err instanceof Error ? err.message : err), "Failed to access typegate: request failed with status 401 (Unauthorized)");
+    }
+  },
+);

--- a/tests/e2e/self_deploy/self_deploy_test.ts
+++ b/tests/e2e/self_deploy/self_deploy_test.ts
@@ -21,7 +21,7 @@ Meta.test(
     const { serialized, response: gateResponseAdd } = await tgDeploy(tg, {
       typegate: { url: gate, auth },
       secrets: {},
-      typegraphPath: path.join(cwdDir, "self_deploy.mjs"),
+      typegraphPath: path.join(cwdDir, "self_deploy.ts"),
       migrationsDir: `${cwdDir}/prisma-migrations`,
       defaultMigrationAction: {
         apply: true,


### PR DESCRIPTION
Solves [MET-793](https://linear.app/metatypedev/issue/MET-793/artifact-upload-allowed-with-wrong-credentials)

#### Migration notes

None

- [x] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a ping functionality to verify typegate connectivity and credentials
  - Introduced a new server health check mechanism across multiple language implementations

- **Improvements**
  - Simplified error handling in deployment and query-related functions
  - Enhanced pre-deployment validation process

- **Testing**
  - Added test coverage for credential validation during deployment
  - Implemented new test scenarios for typegate connectivity checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->