### PR TITLE
fix: hostcall token issue

### DIFF
--- a/src/typegate/src/runtimes/deno/deno.ts
+++ b/src/typegate/src/runtimes/deno/deno.ts
@@ -163,10 +163,7 @@ export class DenoRuntime extends Runtime {
       }
     }
 
-    const token = await InternalAuth.emit(typegate.cryptoKeys);
-
     const hostcallCtx = {
-      authToken: token,
       typegate,
       typegraphUrl: new URL(
         `internal+hostcall+deno://typegate/${typegraphName}`,

--- a/src/typegate/src/runtimes/python.ts
+++ b/src/typegate/src/runtimes/python.ts
@@ -122,10 +122,8 @@ export class PythonRuntime extends Runtime {
 
     // add default vm for lambda/def
     const uuid = crypto.randomUUID();
-    const token = await InternalAuth.emit(typegate.cryptoKeys);
 
     const hostcallCtx = {
-      authToken: token,
       typegate,
       typegraphUrl: new URL(
         `internal+hostcall+witwire://typegate/${typegraphName}`,

--- a/src/typegate/src/runtimes/substantial.ts
+++ b/src/typegate/src/runtimes/substantial.ts
@@ -118,10 +118,7 @@ export class SubstantialRuntime extends Runtime {
       maxAcquirePerTick: typegate.config.base.substantial_max_acquire_per_tick!,
     } satisfies AgentConfig;
 
-    const token = await InternalAuth.emit(typegate.cryptoKeys);
-
     const hostcallCtx = {
-      authToken: token,
       typegate,
       typegraphUrl: new URL(
         `internal+hostcall+subs://typegate/${params.typegraphName}`,

--- a/src/typegate/src/runtimes/wasm_wire.ts
+++ b/src/typegate/src/runtimes/wasm_wire.ts
@@ -53,9 +53,9 @@ export class WasmRuntimeWire extends Runtime {
     };
 
     const uuid = crypto.randomUUID();
-    const token = await InternalAuth.emit(typegate.cryptoKeys);
-    const componentPath =
-      await typegate.artifactStore.getLocalPath(artifactMeta);
+    const componentPath = await typegate.artifactStore.getLocalPath(
+      artifactMeta,
+    );
 
     const wireMat = materializers.map((mat) => ({
       op_name: mat.data.op_name as string,
@@ -66,9 +66,10 @@ export class WasmRuntimeWire extends Runtime {
     }));
 
     const hostcallCtx = {
-      authToken: token,
       typegate,
-      typegraphUrl: new URL(`internal+hostcall+witwire://typegate/${typegraphName}`),
+      typegraphUrl: new URL(
+        `internal+hostcall+witwire://typegate/${typegraphName}`,
+      ),
     };
 
     const workerManager = new WorkerManager(hostcallCtx);

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -62,7 +62,7 @@ ENV GHJK_ENV=oci
 ENV GHJK_ACTIVATE=.ghjk/envs/$GHJK_ENV/activate.sh
 RUN ghjk envs cook
 
-SHELL ["/bin/sh", "-c", ". .ghjk/envs/oci/activate.sh && sh -c \"$*\"", "sh"]
+SHELL ["/bin/sh", "-c", ". ${GHJK_ACTIVATE} && sh -c \"$*\"", "sh"]
 
 COPY --from=plan /app/recipe.json recipe.json
 

--- a/tools/list-duplicates.ts
+++ b/tools/list-duplicates.ts
@@ -337,46 +337,52 @@ export function listDuplicates(tg: TypeGraphDS, rootIdx = 0) {
   }
 }
 
-const args = parseArgs(Deno.args, {
-  string: ["root"],
-});
+// const args = parseArgs(Deno.args, {
+//   string: ["root"],
+// });
+//
+// const rootIdx = argToInt(args.root, 0);
+//
+// const files = args._ as string[];
+// if (files.length === 0) {
+//   throw new Error("Path to typegraph definition module is required.");
+// }
+// if (files.length > 1) {
+//   throw new Error("Cannot accept more than one file");
+// }
+// const cmd = [
+//   "cargo",
+//   "run",
+//   "--manifest-path",
+//   `${projectDir}/Cargo.toml`,
+//   "-p",
+//   "meta-cli",
+//   "--",
+//   "serialize",
+//   "-f",
+//   files[0],
+// ];
+// const { stdout } = await new Deno.Command(cmd[0], {
+//   args: cmd.slice(1),
+//   stdout: "piped",
+//   stderr: "inherit",
+// }).output();
+//
+// function argToInt(arg: string | undefined, defaultValue: number): number {
+//   const parsed = parseInt(arg ?? `${defaultValue}`);
+//   return isNaN(parsed) ? defaultValue : parsed;
+// }
 
-const rootIdx = argToInt(args.root, 0);
-
-const files = args._ as string[];
-if (files.length === 0) {
-  throw new Error("Path to typegraph definition module is required.");
+let raw = "";
+const decoder = new TextDecoder();
+for await (const chunk of Deno.stdin.readable) {
+  raw += decoder.decode(chunk);
+  // do something with the text
 }
-if (files.length > 1) {
-  throw new Error("Cannot accept more than one file");
-}
-const cmd = [
-  "cargo",
-  "run",
-  "--manifest-path",
-  `${projectDir}/Cargo.toml`,
-  "-p",
-  "meta-cli",
-  "--",
-  "serialize",
-  "-f",
-  files[0],
-];
-const { stdout } = await new Deno.Command(cmd[0], {
-  args: cmd.slice(1),
-  stdout: "piped",
-  stderr: "inherit",
-}).output();
 
-const tgs: TypeGraphDS[] = JSON.parse(
-  new TextDecoder().decode(stdout),
-);
+// const raw = new TextDecoder().decode(stdout),
+const tgs: TypeGraphDS[] = JSON.parse(raw);
 
 for (const tg of tgs) {
-  listDuplicatesEnhanced(tg, rootIdx);
-}
-
-function argToInt(arg: string | undefined, defaultValue: number): number {
-  const parsed = parseInt(arg ?? `${defaultValue}`);
-  return isNaN(parsed) ? defaultValue : parsed;
+  listDuplicatesEnhanced(tg, 0);
 }


### PR DESCRIPTION
- Fixes issue with internal auth tokens for the hostcall transport going stale due to being only created at init of runtime

#### Migration notes

---

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal authentication handling to dynamically generate tokens during GraphQL host calls, rather than passing pre-existing tokens in the context.
  - Simplified context objects by removing the authentication token property from multiple runtime initializations.
  - Adjusted Dockerfile to use a dynamic environment variable for sourcing the activation script.
  - Modified duplicate listing tool to read JSON input directly from standard input, streamlining its workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->