### PR TITLE
fix: metagen select in client_ts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13081,6 +13081,7 @@ name = "typegraph"
 version = "0.5.1-rc.2"
 dependencies = [
  "color-eyre",
+ "derive_more 1.0.0",
  "enum_dispatch",
  "indexmap 2.6.0",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ lazy_static = "1.5.0"                                # FIXME: replace with Lazy 
 crossbeam-channel = "0.5.13"
 enum_dispatch = "0.3.13"
 tap = "1.0.1"
-derive_more = { version = "1", features = ["from"] }
+derive_more = { version = "1", features = ["from", "debug"] }
 cached = "0.53.1"                                    # FIXME: replace usage with a Lazy Cell + dashmap
 garde = "0.20"
 paste = "1.0.15"

--- a/src/typegraph/graph/Cargo.toml
+++ b/src/typegraph/graph/Cargo.toml
@@ -12,6 +12,7 @@ indexmap.workspace = true
 paste.workspace = true
 color-eyre.workspace = true
 tracing.workspace = true
+derive_more.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/src/typegraph/graph/src/types/list.rs
+++ b/src/typegraph/graph/src/types/list.rs
@@ -6,9 +6,10 @@ use crate::conv::dedup::{DupKey, DupKeyGen};
 use crate::conv::key::TypeKeyEx;
 use crate::{interlude::*, Arc, Once};
 
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub struct ListType {
     pub base: TypeBase,
+    #[debug("{:?}", item.get().map(|ty| ty.tag()))]
     pub(crate) item: Once<Type>,
     pub min_items: Option<u32>,
     pub max_items: Option<u32>,

--- a/src/typegraph/graph/src/types/object.rs
+++ b/src/typegraph/graph/src/types/object.rs
@@ -9,8 +9,9 @@ use crate::policies::PolicySpec;
 use crate::{interlude::*, TypeNodeExt as _};
 use indexmap::IndexMap;
 
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub struct ObjectProperty {
+    #[debug("{}", ty.tag())]
     pub ty: Type,
     pub policies: Vec<PolicySpec>,
     pub injection: Option<Arc<InjectionNode>>,

--- a/src/typegraph/graph/src/types/optional.rs
+++ b/src/typegraph/graph/src/types/optional.rs
@@ -7,9 +7,10 @@ use crate::conv::key::TypeKeyEx;
 use crate::{interlude::*, TypeNodeExt as _};
 use crate::{Arc, Once};
 
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub struct OptionalType {
     pub base: TypeBase,
+    #[debug("{}", item.get().map(|ty| ty.tag()).unwrap_or("<unset>"))]
     pub(crate) item: Once<Type>,
     pub default_value: Option<serde_json::Value>,
 }

--- a/src/typegraph/graph/src/types/union.rs
+++ b/src/typegraph/graph/src/types/union.rs
@@ -7,9 +7,10 @@ use crate::conv::key::TypeKeyEx;
 use crate::{interlude::*, TypeNodeExt as _};
 use crate::{Arc, Once};
 
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub struct UnionType {
     pub base: TypeBase,
+    #[debug("{:?}", variants.get().map(|i| i.iter().map(|v| v.tag()).collect::<Vec<_>>()))]
     pub(crate) variants: Once<Vec<Type>>,
     pub either: bool,
 }


### PR DESCRIPTION
<!--
Pull requests are squashed and merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog.
-->

<!-- 1. Explain WHAT the change is about -->

- Fix selection for optional types in metagen

<!-- 2. Explain WHY the change cannot be made simpler -->



<!-- 3. Explain HOW users should update their code -->

#### Migration notes

---

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for alias selections in the selection system, improving handling of optional and list types.

- **Style**
  - Enhanced debug output for various type structures, including list, object property, optional, and union types, to display more concise and informative information during debugging.

- **Chores**
  - Updated dependencies to enable additional features for improved debugging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->