### PR TITLE
fix(sub): recover from broken run + race conditions

### DIFF
--- a/src/substantial/src/converters.rs
+++ b/src/substantial/src/converters.rs
@@ -134,7 +134,7 @@ impl Run {
 
     /// Try to recover from dups such as
     ///
-    /// ```
+    /// ```ignore
     ///  [Start Start ...] or
     ///  [... Stop Stop] or
     ///  [ .... Event X Event X ... ]
@@ -146,6 +146,7 @@ impl Run {
     /// we throw by default but realistically we can recover.
     ///
     /// WARN: undesirable side effects can still happen if we crash before saving the Saved results.
+    ///
     pub fn compact(&mut self) {
         let mut operations = Vec::new();
         let mut dup_schedules = HashSet::new();

--- a/src/substantial/src/converters.rs
+++ b/src/substantial/src/converters.rs
@@ -1,7 +1,7 @@
 // Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{bail, Context, Ok, Result};
 use chrono::{DateTime, Utc};
@@ -104,12 +104,15 @@ impl Run {
                     format!("Recovering operations from backend for {}", self.run_id)
                 })?;
             self.operations = operations;
+            self.compact();
         }
 
         Ok(())
     }
 
-    pub fn persist_into(&self, backend: &dyn Backend) -> Result<()> {
+    pub fn persist_into(&mut self, backend: &dyn Backend) -> Result<()> {
+        self.compact();
+
         let mut records = Records::new();
         records.events = self
             .operations
@@ -127,6 +130,35 @@ impl Run {
 
     pub fn reset(&mut self) {
         self.operations = vec![];
+    }
+
+    /// Try to recover from dups such as
+    ///
+    /// ```
+    ///  [Start Start ...] or
+    ///  [... Stop Stop] or
+    ///  [ .... Event X Event X ... ]
+    /// ```
+    ///
+    /// These dups can occur when we crash at a given timing
+    /// and the underlying event of the appointed schedule was not closed.
+    /// The engine will happily append onto the operation log,
+    /// we throw by default but realistically we can recover.
+    ///
+    /// WARN: undesirable side effects can still happen if we crash before saving the Saved results.
+    pub fn compact(&mut self) {
+        let mut operations = Vec::new();
+        let mut dup_schedules = HashSet::new();
+        for operation in &self.operations {
+            if dup_schedules.contains(&operation.at) {
+                continue;
+            }
+
+            operations.push(operation.clone());
+            dup_schedules.insert(operation.at);
+        }
+
+        self.operations = operations;
     }
 }
 

--- a/src/substantial/tests/mod.rs
+++ b/src/substantial/tests/mod.rs
@@ -211,6 +211,7 @@ mod tests {
             let active_after_renew = backend.active_leases(lifetime).unwrap();
 
             assert_eq!(active_before_exp.len(), 2);
+            assert_eq!(active_after_exp.len(), 1);
             assert_eq!(active_after_exp, vec!["infinitum".to_string()]);
             assert_eq!(active_after_renew.len(), 2);
         }

--- a/src/typegate/engine/src/runtimes/substantial.rs
+++ b/src/typegate/engine/src/runtimes/substantial.rs
@@ -29,6 +29,7 @@ fn init_backend(kind: &SubstantialBackend) -> Result<Rc<dyn Backend>> {
                 .map(|p| PathBuf::from(&p))
                 .expect("invalid TMP_DIR");
             let root = tmp_dir.join("substantial").join("fs_backend");
+            tracing::debug!("Fs Backend root directory {root:?}");
 
             Ok(Rc::new(FsBackend::new(root).get()))
         }
@@ -239,7 +240,7 @@ pub struct ActiveLeaseInput {
     pub lease_seconds: u32,
 }
 
-#[tracing::instrument(/*ret,*/ level = "debug", skip(state))]
+// #[tracing::instrument(/*ret,*/ level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_agent_active_leases(
@@ -342,7 +343,7 @@ pub struct ReadAllMetadataInput {
     pub run_id: String,
 }
 
-#[tracing::instrument(level = "debug", skip(state))]
+// #[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_read_all(
@@ -378,7 +379,7 @@ pub struct AppendMetadataInput {
     pub content: serde_json::Value,
 }
 
-#[tracing::instrument(level = "debug", skip(state))]
+// #[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_append(
@@ -441,7 +442,7 @@ pub struct ReadWorkflowLinkInput {
     pub workflow_name: String,
 }
 
-#[tracing::instrument(ret, level = "debug", skip(state))]
+// #[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_read_workflow_links(
@@ -471,7 +472,7 @@ pub struct WriteParentChildLinkInput {
     pub child_run_id: String,
 }
 
-#[tracing::instrument(level = "debug", skip(state))]
+// #[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_write_parent_child_link(
@@ -500,7 +501,7 @@ pub struct EnumerateAllChildrenInput {
     pub parent_run_id: String,
 }
 
-#[tracing::instrument(ret, level = "debug", skip(state))]
+// #[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_enumerate_all_children(

--- a/src/typegate/engine/src/runtimes/substantial.rs
+++ b/src/typegate/engine/src/runtimes/substantial.rs
@@ -213,7 +213,7 @@ pub struct NextRunInput {
     pub exclude: Vec<String>,
 }
 
-#[tracing::instrument(ret, level = "debug", skip(state, input))]
+// #[tracing::instrument(ret, level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_agent_next_run(

--- a/src/typegate/engine/src/runtimes/substantial.rs
+++ b/src/typegate/engine/src/runtimes/substantial.rs
@@ -40,18 +40,19 @@ fn init_backend(kind: &SubstantialBackend) -> Result<Rc<dyn Backend>> {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct CreateOrGetInput {
     pub backend: SubstantialBackend,
     pub run_id: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(crate = "serde")]
 pub struct CreateOrGetOutput {
     pub run: Run,
 }
 
+#[tracing::instrument(/*ret, */level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_store_create_or_get_run(
@@ -75,12 +76,13 @@ pub async fn op_sub_store_create_or_get_run(
     Ok(CreateOrGetOutput { run })
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct PersistRunInput {
     pub run: Run,
     pub backend: SubstantialBackend,
 }
 
+#[tracing::instrument(ret, level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 #[string]
 pub async fn op_sub_store_persist_run(
@@ -106,7 +108,7 @@ pub async fn op_sub_store_persist_run(
     Ok(input.run.run_id)
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct AddScheduleInput {
     pub backend: SubstantialBackend,
     pub run_id: String,
@@ -115,6 +117,7 @@ pub struct AddScheduleInput {
     pub operation: Option<Operation>,
 }
 
+#[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 pub async fn op_sub_store_add_schedule(
     state: Rc<RefCell<OpState>>,
@@ -141,7 +144,7 @@ pub async fn op_sub_store_add_schedule(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ReadOrCloseScheduleInput {
     pub backend: SubstantialBackend,
     pub run_id: String,
@@ -149,6 +152,7 @@ pub struct ReadOrCloseScheduleInput {
     pub schedule: DateTime<Utc>,
 }
 
+#[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_store_read_schedule(
@@ -177,6 +181,7 @@ pub async fn op_sub_store_read_schedule(
     }
 }
 
+#[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 pub async fn op_sub_store_close_schedule(
     state: Rc<RefCell<OpState>>,
@@ -198,13 +203,14 @@ pub async fn op_sub_store_close_schedule(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct NextRunInput {
     pub backend: SubstantialBackend,
     pub queue: String,
     pub exclude: Vec<String>,
 }
 
+#[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_agent_next_run(
@@ -227,12 +233,13 @@ pub async fn op_sub_agent_next_run(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ActiveLeaseInput {
     pub backend: SubstantialBackend,
     pub lease_seconds: u32,
 }
 
+#[tracing::instrument(/*ret,*/ level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_agent_active_leases(
@@ -255,13 +262,14 @@ pub async fn op_sub_agent_active_leases(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct LeaseInput {
     pub backend: SubstantialBackend,
     pub run_id: String,
     pub lease_seconds: u32,
 }
 
+#[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 pub async fn op_sub_agent_acquire_lease(
     state: Rc<RefCell<OpState>>,
@@ -283,6 +291,7 @@ pub async fn op_sub_agent_acquire_lease(
         .map_err(OpErr::map())
 }
 
+#[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 pub async fn op_sub_agent_renew_lease(
     state: Rc<RefCell<OpState>>,
@@ -304,6 +313,7 @@ pub async fn op_sub_agent_renew_lease(
         .map_err(OpErr::map())
 }
 
+#[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_agent_remove_lease(
@@ -326,12 +336,13 @@ pub async fn op_sub_agent_remove_lease(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ReadAllMetadataInput {
     pub backend: SubstantialBackend,
     pub run_id: String,
 }
 
+#[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_read_all(
@@ -359,7 +370,7 @@ pub async fn op_sub_metadata_read_all(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct AppendMetadataInput {
     pub backend: SubstantialBackend,
     pub run_id: String,
@@ -367,6 +378,7 @@ pub struct AppendMetadataInput {
     pub content: serde_json::Value,
 }
 
+#[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_append(
@@ -393,13 +405,14 @@ pub async fn op_sub_metadata_append(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct WriteLinkInput {
     pub backend: SubstantialBackend,
     pub workflow_name: String,
     pub run_id: String,
 }
 
+#[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_write_workflow_link(
@@ -422,12 +435,13 @@ pub async fn op_sub_metadata_write_workflow_link(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ReadWorkflowLinkInput {
     pub backend: SubstantialBackend,
     pub workflow_name: String,
 }
 
+#[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_read_workflow_links(
@@ -450,13 +464,14 @@ pub async fn op_sub_metadata_read_workflow_links(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct WriteParentChildLinkInput {
     pub backend: SubstantialBackend,
     pub parent_run_id: String,
     pub child_run_id: String,
 }
 
+#[tracing::instrument(level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_write_parent_child_link(
@@ -479,12 +494,13 @@ pub async fn op_sub_metadata_write_parent_child_link(
         .map_err(OpErr::map())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct EnumerateAllChildrenInput {
     pub backend: SubstantialBackend,
     pub parent_run_id: String,
 }
 
+#[tracing::instrument(ret, level = "debug", skip(state))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_enumerate_all_children(

--- a/src/typegate/engine/src/runtimes/substantial.rs
+++ b/src/typegate/engine/src/runtimes/substantial.rs
@@ -120,7 +120,7 @@ pub struct AddScheduleInput {
     pub operation: Option<Operation>,
 }
 
-#[tracing::instrument(level = "debug", skip(state))]
+#[tracing::instrument(level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 pub async fn op_sub_store_add_schedule(
     state: Rc<RefCell<OpState>>,
@@ -155,7 +155,7 @@ pub struct ReadOrCloseScheduleInput {
     pub schedule: DateTime<Utc>,
 }
 
-#[tracing::instrument(ret, level = "debug", skip(state))]
+#[tracing::instrument(ret, level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_store_read_schedule(
@@ -184,7 +184,7 @@ pub async fn op_sub_store_read_schedule(
     }
 }
 
-#[tracing::instrument(level = "debug", skip(state))]
+#[tracing::instrument(level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 pub async fn op_sub_store_close_schedule(
     state: Rc<RefCell<OpState>>,
@@ -213,7 +213,7 @@ pub struct NextRunInput {
     pub exclude: Vec<String>,
 }
 
-#[tracing::instrument(ret, level = "debug", skip(state))]
+#[tracing::instrument(ret, level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_agent_next_run(
@@ -294,7 +294,7 @@ pub async fn op_sub_agent_acquire_lease(
         .map_err(OpErr::map())
 }
 
-#[tracing::instrument(ret, level = "debug", skip(state))]
+#[tracing::instrument(ret, level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 pub async fn op_sub_agent_renew_lease(
     state: Rc<RefCell<OpState>>,
@@ -316,7 +316,7 @@ pub async fn op_sub_agent_renew_lease(
         .map_err(OpErr::map())
 }
 
-#[tracing::instrument(level = "debug", skip(state))]
+#[tracing::instrument(level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_agent_remove_lease(
@@ -415,7 +415,7 @@ pub struct WriteLinkInput {
     pub run_id: String,
 }
 
-#[tracing::instrument(level = "debug", skip(state))]
+#[tracing::instrument(level = "debug", skip(state, input))]
 #[deno_core::op2(async)]
 #[serde]
 pub async fn op_sub_metadata_write_workflow_link(

--- a/src/typegate/engine/src/runtimes/substantial.rs
+++ b/src/typegate/engine/src/runtimes/substantial.rs
@@ -77,7 +77,7 @@ pub async fn op_sub_store_create_or_get_run(
     Ok(CreateOrGetOutput { run })
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct PersistRunInput {
     pub run: Run,
     pub backend: SubstantialBackend,
@@ -94,6 +94,8 @@ pub async fn op_sub_store_persist_run(
         let state = state.borrow();
         state.borrow::<Ctx>().clone()
     };
+
+    let mut input = input.clone();
 
     let backend = ctx
         .backends

--- a/src/typegate/src/runtimes/substantial.ts
+++ b/src/typegate/src/runtimes/substantial.ts
@@ -4,7 +4,11 @@
 import { Runtime } from "./Runtime.ts";
 import type { Resolver, RuntimeInitParams } from "../types.ts";
 import type { ComputeStage } from "../engine/query_engine.ts";
-import { TypeGraph, type TypeGraphDS, type TypeMaterializer } from "../typegraph/mod.ts";
+import {
+  TypeGraph,
+  type TypeGraphDS,
+  type TypeMaterializer,
+} from "../typegraph/mod.ts";
 import { registerRuntime } from "./mod.ts";
 import { getLogger, getLoggerByAddress, type Logger } from "../log.ts";
 import * as ast from "graphql/ast";
@@ -20,12 +24,9 @@ import {
 } from "./substantial/agent.ts";
 import { closestWord } from "../utils.ts";
 import { InternalAuth } from "../services/auth/protocols/internal.ts";
-import {
-  applyFilter,
-  type ExecutionStatus,
-  type Expr,
-} from "./substantial/filter_utils.ts";
+import { applyFilter, type Expr } from "./substantial/filter_utils.ts";
 import { createTaskId } from "./patterns/worker_manager/mod.ts";
+import type { ExecutionStatus } from "./substantial/common.ts";
 
 const logger = getLogger(import.meta);
 

--- a/src/typegate/src/runtimes/substantial/agent.ts
+++ b/src/typegate/src/runtimes/substantial/agent.ts
@@ -269,6 +269,7 @@ export class Agent {
 
       if (isRunning && isAboutToExpire) {
         this.logger.info(`Renew lease ${runId}, worker is still active`);
+
         await Meta.substantial.agentRenewLease({
           backend: this.backend,
           lease_seconds: this.config.leaseLifespanSec,
@@ -278,6 +279,12 @@ export class Agent {
 
       if (!isRunning) {
         this.mustLockRunIds.delete(runId);
+        this.logger.info(`Remove lease ${runId}`);
+        await Meta.substantial.agentRemoveLease({
+          backend: this.backend,
+          lease_seconds: this.config.leaseLifespanSec,
+          run_id: runId,
+        });
       }
     }
   }
@@ -527,6 +534,8 @@ export class Agent {
       run_id: runId,
       lease_seconds: this.config.leaseLifespanSec,
     });
+
+    this.mustLockRunIds.delete(runId);
   }
 }
 

--- a/src/typegate/src/runtimes/substantial/agent.ts
+++ b/src/typegate/src/runtimes/substantial/agent.ts
@@ -58,8 +58,8 @@ export class Agent {
     this.logger = getLoggerByAddress(import.meta, "substantial");
     this.mustLockRunIds = new Map();
 
-    this.pollInterval = new BlockingInterval(this.logger);
-    this.hearbeatInterval = new BlockingInterval(this.logger);
+    this.pollInterval = new BlockingInterval();
+    this.hearbeatInterval = new BlockingInterval();
   }
 
   async schedule(input: AddScheduleInput) {

--- a/src/typegate/src/runtimes/substantial/common.ts
+++ b/src/typegate/src/runtimes/substantial/common.ts
@@ -109,12 +109,16 @@ export class Interrupt extends Error {
   }
 }
 
+export function runHasStarted(run: Run) {
+  return run.operations.some(({ event }) => event.type == "Start");
+}
+
 export function runHasStopped(run: Run) {
   return run.operations.some(({ event }) => event.type == "Stop");
 }
 
 export function checkOperationHasBeenScheduled(run: Run, operation: Operation) {
   return run.operations.some(({ at, event }) =>
-    at == operation.at && event == operation.event
+    at == operation.at && event.type == operation.event.type
   );
 }

--- a/src/typegate/src/runtimes/substantial/common.ts
+++ b/src/typegate/src/runtimes/substantial/common.ts
@@ -63,6 +63,12 @@ export type Result<T> = {
 
 export type ExecutionResultKind = "SUCCESS" | "FAIL";
 
+export type ExecutionStatus =
+  | "COMPLETED"
+  | "COMPLETED_WITH_ERROR"
+  | "ONGOING"
+  | "UNKNOWN";
+
 // TODO: convert python exceptions into these
 // by using prefixes on the exception message for example
 
@@ -103,9 +109,12 @@ export class Interrupt extends Error {
   }
 }
 
-export function appendIfOngoing(run: Run, operation: Operation) {
-  const hasStopped = run.operations.some(({ event }) => event.type == "Stop");
-  if (!hasStopped) {
-    run.operations.push(operation);
-  }
+export function runHasStopped(run: Run) {
+  return run.operations.some(({ event }) => event.type == "Stop");
+}
+
+export function checkOperationHasBeenScheduled(run: Run, operation: Operation) {
+  return run.operations.some(({ at, event }) =>
+    at == operation.at && event == operation.event
+  );
 }

--- a/src/typegate/src/runtimes/substantial/deno_context.ts
+++ b/src/typegate/src/runtimes/substantial/deno_context.ts
@@ -34,7 +34,11 @@ export class Context {
 
   #appendOp(op: OperationEvent) {
     if (!runHasStopped(this.run)) {
-      console.log("Append context", op.type);
+      // console.log(
+      //   "Append context",
+      //   op.type,
+      //   this.run.operations.map((o) => o.event.type),
+      // );
       this.run.operations.push({ at: new Date().toJSON(), event: op });
     }
   }

--- a/src/typegate/src/runtimes/substantial/deno_context.ts
+++ b/src/typegate/src/runtimes/substantial/deno_context.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type { HostcallPump } from "../../worker_utils.ts";
-import { appendIfOngoing, Interrupt, type OperationEvent, type Run } from "./types.ts";
+import {
+  Interrupt,
+  type OperationEvent,
+  type Run,
+  runHasStopped,
+} from "./common.ts";
 
 // const isTest = Deno.env.get("DENO_TESTING") === "true";
 // const testBaseUrl = Deno.env.get("TEST_OVERRIDE_GQL_ORIGIN");
@@ -28,7 +33,10 @@ export class Context {
   }
 
   #appendOp(op: OperationEvent) {
-    appendIfOngoing(this.run, { at: new Date().toJSON(), event: op });
+    if (!runHasStopped(this.run)) {
+      console.log("Append context", op.type);
+      this.run.operations.push({ at: new Date().toJSON(), event: op });
+    }
   }
 
   async save<T>(fn: () => T | Promise<T>, option?: SaveOption) {

--- a/src/typegate/src/runtimes/substantial/filter_utils.ts
+++ b/src/typegate/src/runtimes/substantial/filter_utils.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type { Agent } from "./agent.ts";
-
-export type ExecutionStatus =
-  | "COMPLETED"
-  | "COMPLETED_WITH_ERROR"
-  | "ONGOING"
-  | "UNKNOWN";
+import type { ExecutionStatus } from "./common.ts";
 
 type KVHelper<T extends string[], V> = {
   // should be a union type but it is not very helpful with autocomplete

--- a/src/typegate/src/runtimes/substantial/worker.ts
+++ b/src/typegate/src/runtimes/substantial/worker.ts
@@ -4,7 +4,11 @@
 import { errorToString, HostcallPump } from "../../worker_utils.ts";
 import { Context } from "./deno_context.ts";
 import { toFileUrl } from "@std/path/to-file-url";
-import { Interrupt, type WorkflowEvent, type WorkflowMessage } from "./types.ts";
+import {
+  Interrupt,
+  type WorkflowEvent,
+  type WorkflowMessage,
+} from "./common.ts";
 
 let runCtx: Context | undefined;
 const hostcallPump = new HostcallPump();

--- a/src/typegate/src/runtimes/substantial/workflow_worker_manager.ts
+++ b/src/typegate/src/runtimes/substantial/workflow_worker_manager.ts
@@ -8,7 +8,7 @@ import { DenoWorker } from "../patterns/worker_manager/deno.ts";
 import { BaseWorkerManager } from "../patterns/worker_manager/mod.ts";
 import { WorkerPool } from "../patterns/worker_manager/pooling.ts";
 import type { EventHandler, TaskId } from "../patterns/worker_manager/types.ts";
-import type { Run, WorkflowEvent, WorkflowMessage } from "./types.ts";
+import type { Run, WorkflowEvent, WorkflowMessage } from "./common.ts";
 
 const logger = getLogger(import.meta, "WARN");
 

--- a/tests/runtimes/substantial/filter_utils_test.ts
+++ b/tests/runtimes/substantial/filter_utils_test.ts
@@ -5,10 +5,10 @@ import { assertEquals } from "@std/assert";
 import { Meta } from "../../utils/mod.ts";
 import {
   evalExpr,
-  type ExecutionStatus,
   type Expr,
   SearchItem,
 } from "@metatype/typegate/runtimes/substantial/filter_utils.ts";
+import type { ExecutionStatus } from "@metatype/typegate/runtimes/substantial/common.ts";
 
 function addDays(date: Date, days: number) {
   const ret = new Date(date);

--- a/tools/compose/compose.subredis.yml
+++ b/tools/compose/compose.subredis.yml
@@ -7,3 +7,12 @@ services:
       - "6380:6379"
     environment:
       REDIS_PASSWORD: password
+  redis-commander:
+    container_name: redis-commander
+    hostname: redis-commander
+    image: ghcr.io/joeferner/redis-commander:latest
+    restart: always
+    environment:
+      - REDIS_HOSTS=local:subredis:6379:0:password
+    ports:
+      - "6390:8081"


### PR DESCRIPTION
* Broken run
1. Detect already handled schedules but interrupted before closing then close/skip them 
2. Try to recover from schedule dups such as

```
 [Start Start ...] or
 [... Stop Stop] or
 [ .... Event X Event X ... ]
```

These dups can occur when we crash at a given timing and the underlying event of the appointed schedule was not closed. The engine will happily append onto the operation log, we throw by default but realistically we can recover.
However 1. should make sure dups do  not occur accross all nodes, this should mitigate unknown unknowns (timestamp identifies schedules so it should be safe).
WARN: Undesirable side effects cannot be ruled out if we crash before saving the Saved results.

* Moved from setInterval to a custom blocking async interval
* Changed lease renew logic
#### Migration notes

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a Redis Commander service for easier Redis database management via a web interface.
  - Introduced lease heartbeat renewal to automatically manage lease lifetimes.
  - Added asynchronous interval control to ensure sequential execution of recurring tasks.

- **Bug Fixes**
  - Improved handling of duplicate operations and run state validation to prevent data inconsistencies and duplicate scheduling.
  - Enhanced logic to prevent appending operations to stopped runs.
  - Added run log integrity validation to detect corrupted or overlapping run states.

- **Refactor**
  - Replaced and reorganized utility functions for checking run status and operation scheduling.
  - Updated type definitions and imports for better code clarity and maintainability.
  - Improved logging, debugging, and tracing for better observability and troubleshooting.
  - Replaced standard intervals with controlled async intervals to avoid concurrency issues.

- **Tests**
  - Added assertions to verify lease expiration and run state consistency.

- **Style**
  - Reformatted import statements for consistency and readability.

- **Documentation**
  - Added comments and documentation to clarify lease handling, concurrency, and run integrity validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->