### PR TITLE
refactor: ordered recieve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ examples/typegraphs/**/*.wasm
 src/pyrt_wit_wire/wit_wire
 
 /.metatype/
+play.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "archive_utils"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "grpc_utils"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "proto-parser",
@@ -6623,7 +6623,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identities_fdk"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "metagen-client",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "meta-cli"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "actix",
  "archive_utils",
@@ -7850,7 +7850,7 @@ dependencies = [
 
 [[package]]
 name = "metagen"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "color-eyre",
  "dashmap 6.1.0",
@@ -7876,7 +7876,7 @@ dependencies = [
 
 [[package]]
 name = "metagen-client"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "derive_more 1.0.0",
  "futures",
@@ -8271,7 +8271,7 @@ dependencies = [
 
 [[package]]
 name = "mt_deno"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "deno",
@@ -11348,7 +11348,7 @@ dependencies = [
 
 [[package]]
 name = "sample_client"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "metagen-client",
  "serde",
@@ -11358,7 +11358,7 @@ dependencies = [
 
 [[package]]
 name = "sample_client_upload"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "metagen-client",
  "serde",
@@ -12574,7 +12574,7 @@ dependencies = [
 
 [[package]]
 name = "substantial"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -13386,7 +13386,7 @@ dependencies = [
 
 [[package]]
 name = "tg_schema"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -14112,7 +14112,7 @@ dependencies = [
 
 [[package]]
 name = "typegate"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "colored 2.1.0",
  "env_logger 0.11.0",
@@ -14125,7 +14125,7 @@ dependencies = [
 
 [[package]]
 name = "typegate_api"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14142,7 +14142,7 @@ dependencies = [
 
 [[package]]
 name = "typegate_engine"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "archive_utils",
@@ -14191,7 +14191,7 @@ dependencies = [
 
 [[package]]
 name = "typegraph"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "color-eyre",
  "derive_more 1.0.0",
@@ -14207,7 +14207,7 @@ dependencies = [
 
 [[package]]
 name = "typegraph_core"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "archive_utils",
@@ -14983,14 +14983,14 @@ dependencies = [
 
 [[package]]
 name = "wasm_reflected_rust"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "wit-bindgen 0.34.0",
 ]
 
 [[package]]
 name = "wasm_wire_rust"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "metagen-client",
@@ -16314,7 +16314,7 @@ checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xtask"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 edition = "2021"
 
 [workspace.dependencies]

--- a/docs/metatype.dev/docs/reference/typegate/authentication/index.mdx
+++ b/docs/metatype.dev/docs/reference/typegate/authentication/index.mdx
@@ -152,7 +152,7 @@ const claims = await fetch(
     body: JSON.stringify({
       grant_type: "refresh_token",
       refresh_token: "refresh_token",
-      client_id: "client_id"
+      client_id: "client_id",
     }),
   },
 );

--- a/docs/metatype.dev/docs/reference/typegate/authentication/index.mdx
+++ b/docs/metatype.dev/docs/reference/typegate/authentication/index.mdx
@@ -96,7 +96,7 @@ The typegate uses [PKCE](https://www.oauth.com/oauth2-servers/pkce/authorization
 - `code`: The authorization code from the typegate
 - `code_verifier`: The inital code verifier
 - `grant_type`: Set to `authorization_code`
-- `client_id`: The previous client id
+- `client_id`: The set client id
 - `redirect_uri`: The previous redirect URI
 
 ```typescript
@@ -140,6 +140,7 @@ query={require("./oauth2.graphql")} headers={{
 
 - `grant_type`: Set to `refresh_token`
 - `refresh_token`: The previously received refresh token
+- `client_id`: The set client id
 - `scope`: The new token scope (optional)
 
 ```typescript
@@ -151,6 +152,7 @@ const claims = await fetch(
     body: JSON.stringify({
       grant_type: "refresh_token",
       refresh_token: "refresh_token",
+      client_id: "client_id"
     }),
   },
 );

--- a/examples/templates/deno/api/example.ts
+++ b/examples/templates/deno/api/example.ts
@@ -1,6 +1,6 @@
-import { Policy, t, typegraph } from "jsr:@typegraph/sdk@0.5.1-rc.5";
-import { PythonRuntime } from "jsr:@typegraph/sdk@0.5.1-rc.5/runtimes/python";
-import { DenoRuntime } from "jsr:@typegraph/sdk@0.5.1-rc.5/runtimes/deno";
+import { Policy, t, typegraph } from "jsr:@typegraph/sdk@0.5.1-rc.6";
+import { PythonRuntime } from "jsr:@typegraph/sdk@0.5.1-rc.6/runtimes/python";
+import { DenoRuntime } from "jsr:@typegraph/sdk@0.5.1-rc.6/runtimes/deno";
 
 await typegraph("example", (g) => {
   const pub = Policy.public();

--- a/examples/templates/deno/compose.yml
+++ b/examples/templates/deno/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.5.1-rc.5
+    image: ghcr.io/metatypedev/typegate:v0.5.1-rc.6
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/compose.yml
+++ b/examples/templates/node/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.5.1-rc.5
+    image: ghcr.io/metatypedev/typegate:v0.5.1-rc.6
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/node/package.json
+++ b/examples/templates/node/package.json
@@ -6,7 +6,7 @@
     "dev": "MCLI_LOADER_CMD='npm x tsx' meta dev"
   },
   "dependencies": {
-    "@typegraph/sdk": "^0.5.1-rc.5"
+    "@typegraph/sdk": "^0.5.1-rc.6"
   },
   "devDependencies": {
     "tsx": "^3.13.0",

--- a/examples/templates/python/compose.yml
+++ b/examples/templates/python/compose.yml
@@ -1,6 +1,6 @@
 services:
   typegate:
-    image: ghcr.io/metatypedev/typegate:v0.5.1-rc.5
+    image: ghcr.io/metatypedev/typegate:v0.5.1-rc.6
     restart: always
     ports:
       - "7890:7890"

--- a/examples/templates/python/pyproject.toml
+++ b/examples/templates/python/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "example"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 description = ""
 authors = []
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-typegraph = "0.5.1-rc.5"
+typegraph = "0.5.1-rc.6"
 
 [build-system]
 requires = ["poetry-core"]

--- a/ghjk.ts
+++ b/ghjk.ts
@@ -12,6 +12,7 @@ import {
 import { validateVersions } from "./tools/tasks/lock.ts";
 import installs from "./tools/installs.ts";
 import tasks from "./tools/tasks/mod.ts";
+import { semver } from "./tools/deps.ts";
 
 const ghjk = file({
   defaultEnv: Deno.env.get("CI") ? "ci" : Deno.env.get("OCI") ? "oci" : "dev",

--- a/metatype
+++ b/metatype
@@ -1,0 +1,1 @@
+/home/asdf/repos/rust/metatype/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "metatype"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 description = ""
 authors = []
 

--- a/src/meta-cli/src/typegraph/rpc/mod.rs
+++ b/src/meta-cli/src/typegraph/rpc/mod.rs
@@ -20,8 +20,8 @@ pub trait RpcDispatch {
 #[enum_dispatch(RpcDispatch)]
 #[serde(untagged)]
 pub enum RpcCall {
-    Aws(aws::RpcCall),
-    Core(core::RpcCall),
     Runtimes(runtimes::RpcCall),
     Utils(utils::RpcCall),
+    Core(core::RpcCall),
+    Aws(aws::RpcCall),
 }

--- a/src/pyrt_wit_wire/pyproject.toml
+++ b/src/pyrt_wit_wire/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyrt_wit_wire"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 description = "Wasm component implementing the PythonRuntime host using wit_wire protocol."
 license = "MPL-2.0"
 readme = "README.md"

--- a/src/typegate/src/errors.ts
+++ b/src/typegate/src/errors.ts
@@ -57,7 +57,9 @@ export class BaseError extends Error {
   toResponse(headers: Headers = new Headers(), graphqlFormat = true): Response {
     const type = this.#type ?? this.constructor.name;
     logger.error(
-      `${type}[${this.kind}:${this.module ?? ""}] | HTTP ${this.code} | ${this.message}`,
+      `${type}[${this.kind}:${
+        this.module ?? ""
+      }] | HTTP ${this.code} | ${this.message}`,
     );
     if (globalConfig.debug) {
       logger.error(this.stack);

--- a/src/typegate/src/errors.ts
+++ b/src/typegate/src/errors.ts
@@ -57,13 +57,11 @@ export class BaseError extends Error {
   toResponse(headers: Headers = new Headers(), graphqlFormat = true): Response {
     const type = this.#type ?? this.constructor.name;
     logger.error(
-      `${type}[${this.kind}:${this.module ?? ""}]: ${this.message}`,
+      `${type}[${this.kind}:${this.module ?? ""}] | HTTP ${this.code} | ${this.message}`,
     );
     if (globalConfig.debug) {
       logger.error(this.stack);
     }
-    logger.warn("Responding with HTTP {}", this.code);
-
     let responseObj;
     if (graphqlFormat) {
       // formatted in graphql error format

--- a/src/typegate/src/log.ts
+++ b/src/typegate/src/log.ts
@@ -125,7 +125,6 @@ const consoleHandler = panicLevelName
   );
 
 const loggers = new Map<string, std_log.Logger>([
-  // the default logger
   [
     "",
     new std_log.Logger("default", "NOTSET", {
@@ -136,7 +135,7 @@ const loggers = new Map<string, std_log.Logger>([
 
 export function getLogger(
   name: ImportMeta | string = self.name, // use name of worker by default
-  levelName: std_log.LevelName = "NOTSET",
+  levelName?: std_log.LevelName,
 ): std_log.Logger {
   if (typeof name === "object") {
     const bname = basename(name.url);
@@ -145,23 +144,13 @@ export function getLogger(
   }
   let logger = loggers.get(name);
   if (!logger) {
-    logger = new std_log.Logger(name, levelName, {
+    const level = sharedConfig.log_level?.[name] ?? levelName ?? "NOTSET";
+    logger = new std_log.Logger(name, level, {
       handlers: [consoleHandler],
     });
     loggers.set(name, logger);
   }
   return logger;
-}
-
-export function getLoggerByAddress(
-  name: ImportMeta | string = self.name,
-  address: string,
-) {
-  const levelForAddress = sharedConfig?.log_level?.[address];
-
-  return levelForAddress
-    ? getLogger(name, levelForAddress)
-    : getLogger(name, ADDRESSED_DEFAULT_LEVEL);
 }
 
 let colorEnvFlagSet = false;

--- a/src/typegate/src/log.ts
+++ b/src/typegate/src/log.ts
@@ -5,11 +5,7 @@ import * as std_log from "@std/log";
 export { Logger } from "@std/log";
 import * as std_fmt_colors from "@std/fmt/colors";
 import { basename, dirname, extname } from "@std/path";
-import {
-  ADDRESSED_DEFAULT_LEVEL,
-  MAIN_DEFAULT_LEVEL,
-  sharedConfig,
-} from "./config/shared.ts";
+import { MAIN_DEFAULT_LEVEL, sharedConfig } from "./config/shared.ts";
 
 // set rust log level is not explicit set
 if (!sharedConfig.rust_log) {

--- a/src/typegate/src/runtimes/substantial.ts
+++ b/src/typegate/src/runtimes/substantial.ts
@@ -10,7 +10,7 @@ import {
   type TypeMaterializer,
 } from "../typegraph/mod.ts";
 import { registerRuntime } from "./mod.ts";
-import { getLogger, getLoggerByAddress, type Logger } from "../log.ts";
+import { getLogger, type Logger } from "../log.ts";
 import * as ast from "graphql/ast";
 import { path } from "compress/deps.ts";
 import type { Artifact } from "../typegraph/types.ts";
@@ -85,7 +85,7 @@ export class SubstantialRuntime extends Runtime {
     private secrets: Record<string, string>,
   ) {
     super(typegraphName);
-    this.logger = getLoggerByAddress(import.meta, "substantial");
+    this.logger = getLogger(import.meta);
     this.backend = backend;
     this.queue = queue;
     this.agent = agent;

--- a/src/typegate/src/runtimes/substantial/agent.ts
+++ b/src/typegate/src/runtimes/substantial/agent.ts
@@ -9,7 +9,7 @@ import type {
   ReadOrCloseScheduleInput,
   Run,
 } from "../../../engine/runtime.js";
-import { getLoggerByAddress, type Logger } from "../../log.ts";
+import { getLogger, type Logger } from "../../log.ts";
 import type { TaskContext } from "../deno/shared_types.ts";
 import { getTaskNameFromId } from "../patterns/worker_manager/mod.ts";
 import type { EventHandler } from "../patterns/worker_manager/types.ts";
@@ -55,7 +55,7 @@ export class Agent {
     private queue: string,
     private config: AgentConfig,
   ) {
-    this.logger = getLoggerByAddress(import.meta, "substantial");
+    this.logger = getLogger(import.meta);
     this.mustLockRunIds = new Map();
 
     this.pollInterval = new BlockingInterval();
@@ -560,7 +560,7 @@ function prettyRun(run: Run) {
 }
 
 function validateRunIntegrity(run: Run) {
-  const logger = getLoggerByAddress(import.meta, "substantial");
+  const logger = getLogger(import.meta);
 
   let life = 0;
 

--- a/src/typegate/src/runtimes/substantial/worker.ts
+++ b/src/typegate/src/runtimes/substantial/worker.ts
@@ -54,7 +54,9 @@ self.onmessage = async function (event: MessageEvent<WorkflowMessage>) {
         }).gql,
       );
 
-      workflowFn(runCtx, internal)
+      // wrap in async function to
+      // avoid sync+Promise.resolve footgun
+      (async () => await workflowFn(runCtx, internal))()
         .then((wfResult: unknown) => {
           self.postMessage(
             {

--- a/src/typegate/src/runtimes/wit_wire/mod.ts
+++ b/src/typegate/src/runtimes/wit_wire/mod.ts
@@ -8,7 +8,7 @@ import { Meta } from "../../../engine/runtime.js";
 //
 // const logger = getLogger(import.meta);
 
-const METATYPE_VERSION = "0.5.1-rc.5";
+const METATYPE_VERSION = "0.5.1-rc.6";
 
 export class WitWireHandle {
   static async init(params: {

--- a/src/typegate/src/services/auth/protocols/oauth2.ts
+++ b/src/typegate/src/services/auth/protocols/oauth2.ts
@@ -69,7 +69,12 @@ class AuthProfiler {
     });
   }
 
-  async transform(request: Request, clientId: string, profile?: any, scope?: string) {
+  async transform(
+    request: Request,
+    clientId: string,
+    profile?: any,
+    scope?: string,
+  ) {
     const { tg, runtimeReferences } = this.authParameters;
     const funcNode = tg.type(this.funcIndex, Type.FUNCTION);
     const mat = tg.materializer(funcNode.materializer);
@@ -285,7 +290,8 @@ export class OAuth2Auth extends Protocol {
 
     if (query.redirect_uri !== userRedirectUri) {
       return jsonError({
-        message: `invalid redirect_uri parameter: ${query.redirect_uri} !== ${userRedirectUri}`,
+        message:
+          `invalid redirect_uri parameter: ${query.redirect_uri} !== ${userRedirectUri}`,
         status: 400,
       });
     }
@@ -396,7 +402,12 @@ export class OAuth2Auth extends Protocol {
     scope?: string,
   ) {
     if (this.authProfiler) {
-      profile = await this.authProfiler!.transform(request, clientId, profile, scope);
+      profile = await this.authProfiler!.transform(
+        request,
+        clientId,
+        profile,
+        scope,
+      );
     }
 
     const payload = {

--- a/src/typegate/src/services/auth/routes/token.ts
+++ b/src/typegate/src/services/auth/routes/token.ts
@@ -106,7 +106,7 @@ export async function token(params: RouteParams) {
         throw new Error(`provider not found: ${provider}`);
       }
 
-      const token = await auth.createJWT(request, profile, state.scope);
+      const token = await auth.createJWT(request, body.client_id, profile, state.scope);
 
       await redis.set(
         `refresh:${token.refresh_token}`,
@@ -139,7 +139,7 @@ export async function token(params: RouteParams) {
         throw new Error(`provider not found: ${provider}`);
       }
 
-      const newTokens = await auth.createJWT(request, profile, body.scope);
+      const newTokens = await auth.createJWT(request, body.client_id, profile, body.scope);
 
       await redis.set(`refresh:${newTokens.refresh_token}`, rawData, {
         ex: engine.tg.typegate.config.base.jwt_refresh_duration_sec,

--- a/src/typegate/src/services/auth/routes/token.ts
+++ b/src/typegate/src/services/auth/routes/token.ts
@@ -25,6 +25,7 @@ const paramSchema = z.union([
     grant_type: z.literal("refresh_token"),
     refresh_token: z.string(),
     scope: z.string().optional(),
+    client_id: z.string(),
   }),
 ]);
 
@@ -106,7 +107,12 @@ export async function token(params: RouteParams) {
         throw new Error(`provider not found: ${provider}`);
       }
 
-      const token = await auth.createJWT(request, body.client_id, profile, state.scope);
+      const token = await auth.createJWT(
+        request,
+        body.client_id,
+        profile,
+        state.scope,
+      );
 
       await redis.set(
         `refresh:${token.refresh_token}`,
@@ -139,7 +145,12 @@ export async function token(params: RouteParams) {
         throw new Error(`provider not found: ${provider}`);
       }
 
-      const newTokens = await auth.createJWT(request, body.client_id, profile, body.scope);
+      const newTokens = await auth.createJWT(
+        request,
+        body.client_id,
+        profile,
+        body.scope,
+      );
 
       await redis.set(`refresh:${newTokens.refresh_token}`, rawData, {
         ex: engine.tg.typegate.config.base.jwt_refresh_duration_sec,

--- a/src/typegate/src/typegate/mod.ts
+++ b/src/typegate/src/typegate/mod.ts
@@ -286,7 +286,7 @@ export class Typegate implements AsyncDisposable {
       }
 
       if (!engineName || ignoreList.has(engineName)) {
-        logger.error("engine not found on request url {}", {
+        logger.error("engine not found on request url", {
           engineName,
           ignored: ignoreList.has(engineName),
           url: request.url,
@@ -296,7 +296,7 @@ export class Typegate implements AsyncDisposable {
 
       const engine = this.register.get(engineName);
       if (!engine) {
-        logger.error("engine not found for request {}", {
+        logger.error("engine not found for request", {
           engineName,
           url: request.url,
           engines: this.register.list().map((en) => en.name),

--- a/src/typegraph/core/Cargo.toml
+++ b/src/typegraph/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typegraph_core"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 edition = "2021"
 
 # this allows us to exclude the rust files

--- a/src/typegraph/core/src/global_store.rs
+++ b/src/typegraph/core/src/global_store.rs
@@ -105,7 +105,7 @@ impl Store {
 
 thread_local! {
     pub static STORE: RefCell<Store> = RefCell::new(Store::new());
-    pub static SDK_VERSION: String = "0.5.1-rc.5".to_owned();
+    pub static SDK_VERSION: String = "0.5.1-rc.6".to_owned();
 }
 
 fn with_store<T, F: FnOnce(&Store) -> T>(f: F) -> T {

--- a/src/typegraph/deno/deno.json
+++ b/src/typegraph/deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@typegraph/sdk",
-  "version": "0.5.1-rc.5",
+  "version": "0.5.1-rc.6",
   "publish": {
     "exclude": ["!src/gen", "!LICENSE.md", "!README.md"]
   },

--- a/src/typegraph/python/pyproject.toml
+++ b/src/typegraph/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typegraph"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 description = "Declarative API development platform. Build backend components with WASM, Typescript and Python, no matter where and how your (legacy) systems are."
 authors = ["Metatype Contributors <support@metatype.dev>"]
 license = "MPL-2.0"

--- a/src/typegraph/python/typegraph/__init__.py
+++ b/src/typegraph/python/typegraph/__init__.py
@@ -5,4 +5,4 @@ from typegraph.graph.typegraph import typegraph, Graph  # noqa
 from typegraph.policy import Policy  # noqa
 from typegraph import effects as fx  # noqa
 
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"

--- a/src/xtask/Cargo.toml
+++ b/src/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 edition = "2021"
 
 # this allows us to exclude the rust files

--- a/tests/auth/auth_test.ts
+++ b/tests/auth/auth_test.ts
@@ -249,6 +249,7 @@ Meta.test(
       const body = JSON.stringify({
         grant_type: "refresh_token",
         refresh_token: nextRefreshToken,
+        client_id: appClientId
       });
       const req = new Request("http://typegate.local/test_auth/auth/token", {
         method: "post",

--- a/tests/auth/auth_test.ts
+++ b/tests/auth/auth_test.ts
@@ -249,7 +249,7 @@ Meta.test(
       const body = JSON.stringify({
         grant_type: "refresh_token",
         refresh_token: nextRefreshToken,
-        client_id: appClientId
+        client_id: appClientId,
       });
       const req = new Request("http://typegate.local/test_auth/auth/token", {
         method: "post",

--- a/tests/metagen/__snapshots__/metagen_test.ts.snap
+++ b/tests/metagen/__snapshots__/metagen_test.ts.snap
@@ -454,7 +454,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.5.1-rc.5";
+        static MT_VERSION: &str = "0.5.1-rc.6";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }
@@ -1253,7 +1253,7 @@ impl Router {
     }
 
     pub fn init(&self, args: InitArgs) -> Result<InitResponse, InitError> {
-        static MT_VERSION: &str = "0.5.1-rc.5";
+        static MT_VERSION: &str = "0.5.1-rc.6";
         if args.metatype_version != MT_VERSION {
             return Err(InitError::VersionMismatch(MT_VERSION.into()));
         }

--- a/tests/metagen/typegraphs/identities/rs/Cargo.toml
+++ b/tests/metagen/typegraphs/identities/rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "identities_fdk"
 edition = "2021"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 
 [dependencies]
 metagen-client = { workspace = true, features = ["graphql"] }

--- a/tests/metagen/typegraphs/sample/rs/Cargo.toml
+++ b/tests/metagen/typegraphs/sample/rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_client"
 edition = "2021"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 
 [dependencies]
 metagen-client = { workspace = true, features = ["graphql"] }

--- a/tests/metagen/typegraphs/sample/rs_upload/Cargo.toml
+++ b/tests/metagen/typegraphs/sample/rs_upload/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_client_upload"
 edition = "2021"
-version = "0.5.1-rc.5"
+version = "0.5.1-rc.6"
 
 [dependencies]
 metagen-client = { workspace = true, features = ["graphql"] }

--- a/tests/runtimes/substantial/common.ts
+++ b/tests/runtimes/substantial/common.ts
@@ -184,6 +184,143 @@ export function basicTestTemplate(
       );
     },
   );
+  Meta.test(
+    {
+      name: `Multi Send events + interrupts (${backendName})`,
+      only,
+    },
+    async (t) => {
+      Deno.env.set("SUB_BACKEND", backendName);
+
+      cleanup && t.addCleanup(cleanup);
+
+      const e = await t.engine("runtimes/substantial/substantial.py", {
+        secrets: {
+          MY_SECRET: "Hello",
+          ...secrets,
+        },
+      });
+
+      let currentRunId: string | null = null;
+      await t.should(
+        `start multiReceive workflow and return its run id (${backendName})`,
+        async () => {
+          await gql`
+            mutation {
+              start_mutli()
+            }
+          `
+            .expectBody((body) => {
+              currentRunId = body.data?.start_mutli! as string;
+              assertExists(
+                currentRunId,
+                "Run id was not returned when workflow was started",
+              );
+            })
+            .on(e);
+        },
+      );
+
+      // Let interrupts to do their jobs for a bit
+      await sleep(10 * 1000); // including remote_add cost (about 1.5s)
+
+      await t.should(
+        `send first event to multiReceive workflow  (${backendName})`,
+        async () => {
+          await gql`
+            query {
+              send_multi(
+                run_id: $run_id
+                event: { payload: "uno" }
+              )
+            }
+          `
+            .withVars({
+              run_id: currentRunId,
+            })
+            .expectData({
+              send_multi: currentRunId,
+            })
+            .on(e);
+        },
+      );
+      await t.should(
+        `send second event to multiReceive workflow  (${backendName})`,
+        async () => {
+          await gql`
+            query {
+              send_multi(
+                run_id: $run_id
+                event: { payload: "duos" }
+              )
+            }
+          `
+            .withVars({
+              run_id: currentRunId,
+            })
+            .expectData({
+              send_multi: currentRunId,
+            })
+            .on(e);
+        },
+      );
+
+      await sleep(delays.awaitSleepCompleteSec * 1000);
+
+      await t.should(
+        `complete multiReceive workflow (${backendName})`,
+        async () => {
+          await gql`
+            query {
+              results(name: "multiReceive") {
+                ongoing {
+                  count
+                }
+                completed {
+                  count
+                  runs {
+                    run_id
+                    result {
+                      status
+                      value
+                    }
+                    logs {
+                      # timestamp
+                      level
+                      value
+                    }
+                  }
+                }
+              }
+            }
+          `
+            .expectData({
+              results: {
+                ongoing: {
+                  count: 0,
+                },
+                completed: {
+                  count: 1,
+                  runs: [
+                    {
+                      run_id: currentRunId,
+                      result: { status: "COMPLETED", value: "Success" },
+                      logs: [
+                        {
+                          level: "Info",
+                          value: JSON.stringify(["uno", "duos"]),
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            })
+            .on(e);
+        },
+      );
+    },
+  );
 }
 
 export function concurrentWorkflowTestTemplate(

--- a/tests/runtimes/substantial/common.ts
+++ b/tests/runtimes/substantial/common.ts
@@ -207,11 +207,11 @@ export function basicTestTemplate(
         async () => {
           await gql`
             mutation {
-              start_mutli()
+              start_multi
             }
           `
             .expectBody((body) => {
-              currentRunId = body.data?.start_mutli! as string;
+              currentRunId = body.data?.start_multi! as string;
               assertExists(
                 currentRunId,
                 "Run id was not returned when workflow was started",
@@ -228,7 +228,7 @@ export function basicTestTemplate(
         `send first event to multiReceive workflow  (${backendName})`,
         async () => {
           await gql`
-            query {
+            mutation {
               send_multi(
                 run_id: $run_id
                 event: { payload: "uno" }
@@ -248,7 +248,7 @@ export function basicTestTemplate(
         `send second event to multiReceive workflow  (${backendName})`,
         async () => {
           await gql`
-            query {
+            mutation {
               send_multi(
                 run_id: $run_id
                 event: { payload: "duos" }

--- a/tests/runtimes/substantial/substantial.py
+++ b/tests/runtimes/substantial/substantial.py
@@ -27,7 +27,7 @@ def substantial(g: Graph):
         .import_(
             [
                 "saveAndSleepExample",
-                "multiRecieve",
+                "multiReceive",
                 "eventsAndExceptionExample",
                 "retryExample",
                 "secretsExample",
@@ -68,15 +68,9 @@ def substantial(g: Graph):
             {"event": {"name": "confirmation", "payload": g.inherit()}}
         ),
         # receive
-        start_multi=sub.start(t.struct({})).reduce(
-            {"name": "multiReceive"}
-        ),
-        send_mutli=sub.send(t.boolean()).reduce(
-            {
-                "event": {
-                    "name": "msg_bus", 
-                    "payload": g.inherit()
-                }}
+        start_multi=sub.start(t.struct({})).reduce({"name": "multiReceive"}),
+        send_multi=sub.send(t.string()).reduce(
+            {"event": {"name": "msg_bus", "payload": g.inherit()}}
         ),
         # retry
         start_retry=sub.start(

--- a/tests/runtimes/substantial/substantial.py
+++ b/tests/runtimes/substantial/substantial.py
@@ -27,6 +27,7 @@ def substantial(g: Graph):
         .import_(
             [
                 "saveAndSleepExample",
+                "multiRecieve",
                 "eventsAndExceptionExample",
                 "retryExample",
                 "secretsExample",
@@ -65,6 +66,17 @@ def substantial(g: Graph):
         ),
         send_confirmation=sub.send(t.boolean()).reduce(
             {"event": {"name": "confirmation", "payload": g.inherit()}}
+        ),
+        # receive
+        start_multi=sub.start(t.struct({})).reduce(
+            {"name": "multiReceive"}
+        ),
+        send_mutli=sub.send(t.boolean()).reduce(
+            {
+                "event": {
+                    "name": "msg_bus", 
+                    "payload": g.inherit()
+                }}
         ),
         # retry
         start_retry=sub.start(

--- a/tests/runtimes/substantial/workflows/workflow.ts
+++ b/tests/runtimes/substantial/workflows/workflow.ts
@@ -28,6 +28,22 @@ export const eventsAndExceptionExample: Workflow<string> = async (
   return `${messageDialog}: confirmed!`;
 };
 
+export const multiReceive: Workflow<string> = (
+  ctx: Context,
+) => {
+  const msg1 = ctx.receive<string>("msg_bus");
+  if (msg1 != "uno") {
+    throw new Error("unexpected msg");
+  }
+  const msg2 = ctx.receive<string>("msg_bus");
+  if (msg2 != "duos") {
+    throw new Error("unexpected msg");
+  }
+  ctx.logger.info(msg1, msg2);
+
+  return Promise.resolve(`Success`);
+};
+
 export async function saveAndSleepExample(ctx: Context) {
   const { a, b } = ctx.kwargs;
   const newA = await ctx.save(() => queryThatTakesAWhile(a as number));

--- a/tests/runtimes/substantial/workflows/workflow.ts
+++ b/tests/runtimes/substantial/workflows/workflow.ts
@@ -28,14 +28,25 @@ export const eventsAndExceptionExample: Workflow<string> = async (
   return `${messageDialog}: confirmed!`;
 };
 
-export const multiReceive: Workflow<string> = (
+export const multiReceive: Workflow<string> = async (
   ctx: Context,
 ) => {
   const msg1 = ctx.receive<string>("msg_bus");
+  await ctx.save(() => {
+    console.log({
+      msg1,
+    });
+  });
   if (msg1 != "uno") {
     throw new Error("unexpected msg");
   }
   const msg2 = ctx.receive<string>("msg_bus");
+  await ctx.save(() => {
+    console.log({
+      msg1,
+      msg2,
+    });
+  });
   if (msg2 != "duos") {
     throw new Error("unexpected msg");
   }

--- a/tools/consts.ts
+++ b/tools/consts.ts
@@ -1,7 +1,7 @@
 // Copyright Metatype OÜ, licensed under the Mozilla Public License Version 2.0.
 // SPDX-License-Identifier: MPL-2.0
 
-export const CURRENT_VERSION = "0.5.1-rc.5";
+export const CURRENT_VERSION = "0.5.1-rc.6";
 export const LATEST_RELEASE_VERSION = "0.5.0";
 export const LATEST_PRE_RELEASE_VERSION = "0.5.1-rc.2";
 export const GHJK_VERSION = "v0.3.1-rc.2";

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -191,9 +191,6 @@ export async function testE2e(args: {
   const xtask = wd.join(`target/${profile}/xtask`);
   const denoConfig = wd.join("deno.jsonc");
 
-  console.log({
-    flags,
-  });
   function createRun(testFile: string, streamed: boolean): Run {
     const start = Date.now();
     const outputOption = streamed ? "inherit" : "piped";


### PR DESCRIPTION
- Message `receive` in substantial now treats the name as a name of a bus and allows multiple messages under the same name
- Bumps version to v0.5.1-rc.6

---

- [x] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new workflow and endpoints for handling multiple event sends and interrupts in the Substantial runtime.
  * Introduced a test case to verify multi-send event and interrupt handling in workflows.

* **Bug Fixes**
  * Improved event processing logic to avoid duplicate handling of events in workflow runs.
  * Ensured workflow execution is consistently treated as asynchronous to prevent execution issues.

* **Refactor**
  * Simplified and updated logging statements and logger initialization across several modules.
  * Removed unused logger utilities and improved log message formatting.
  * Enhanced OAuth2 authentication to include client ID in profiling and JWT creation, improving error diagnostics.

* **Chores**
  * Updated version numbers across all packages, dependencies, and configuration files to 0.5.1-rc.6.
  * Adjusted ignore patterns and removed unnecessary debug output in test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->