### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/docs/metatype.dev/docs/tutorials/quick-start/index.mdx
+++ b/docs/metatype.dev/docs/tutorials/quick-start/index.mdx
@@ -47,7 +47,7 @@ curr. directory      /Users/user/Documents/metatype-playground/projects/first-pr
 global config        /Users/user/Library/Application Support/dev.metatype.meta/config.json
 meta-cli version     0.3.6
 docker version       Docker version 24.0.7, build afdd53b
-containers           bitnami/minio:2022 (Up 3 days), postgres:15 (Up 3 days), bitnami/redis:7.0 (Up 3 days), envoyproxy/envoy:v1.26-latest (Up 3 days), redis:7 (Up 3 days), rabbitmq:3-management (Up 45 hours)
+containers           bitnami/minio:2022 (Up 3 days), postgres:15 (Up 3 days), soldevelo/redis:7.0 (Up 3 days), envoyproxy/envoy:v1.26-latest (Up 3 days), redis:7 (Up 3 days), rabbitmq:3-management (Up 45 hours)
 
 —————————————————————————— Project  ——————————————————————————
 metatype file        metatype.yaml

--- a/tools/compose/compose.base.yml
+++ b/tools/compose/compose.base.yml
@@ -16,7 +16,7 @@ services:
 
   redis:
     # user: root
-    image: docker.io/bitnami/redis:7.0
+    image: docker.io/soldevelo/redis:7.0
     restart: unless-stopped
     ports:
       - "6379:6379"

--- a/tools/compose/compose.subredis.yml
+++ b/tools/compose/compose.subredis.yml
@@ -1,7 +1,7 @@
 services:
   subredis:
     # user: root
-    image: bitnami/redis:7.0
+    image: soldevelo/redis:7.0
     restart: unless-stopped
     ports:
       - "6380:6379"


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/redis:7.0` → [`soldevelo/redis:7.0`](https://hub.docker.com/r/soldevelo/redis)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Redis container image used by the compose setup for both Redis-related services to `soldevelo/redis:7.0` (from `bitnami/redis:7.0`), keeping Redis 7.0.
  * Refreshed the “meta doctor” example output in the quick-start documentation to match the new Redis image reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->